### PR TITLE
Add buy gap decay mode options and analysis

### DIFF
--- a/.codemap-checkout/context-architecture-stage.md
+++ b/.codemap-checkout/context-architecture-stage.md
@@ -1,0 +1,56 @@
+# Context: architecture-stage
+
+Context: architecture-stage
+Title: Architecture Stage Context
+Parent: project
+
+Content:
+# Architecture Stage - Design & Plan
+
+**You are authorized to make design decisions. Design it and move forward.**
+
+## Your Mission Right Now
+
+Design the technical approach. Identify message types, actor boundaries, morphisms, and tests. Document decisions concisely. Then transition to implementation.
+
+## The Flow (Work Continuously)
+
+1. **Study Patterns** (5-10 min)
+   - Search the codebase for similar patterns
+   - Reference havequick: `~/src/havequick/platform/runtime/actor.zig`
+   - Identify which files and modules need changes
+   - Note findings: `git-codemap note bug/name "files: actor/mailbox.go"`
+
+2. **Actor Decomposition** (for actor work)
+   - Define message types (structs with clear fields)
+   - Identify actor boundaries (what state is encapsulated?)
+   - Map message flow (A → B → C)
+   - Identify morphisms (input type → output type)
+   - Note decisions: `git-codemap note bug/name "SpreadActor: BinanceTick+CoinbaseTick → SpreadSignal"`
+
+3. **Categorical Properties** (for ISO work)
+   - Identify monoid/group structure (identity? inverse? associative?)
+   - Define projections (Go type ⇄ Core type)
+   - Plan law verification tests
+   - Note: `git-codemap note bug/name "Spread forms monoid with zero as identity"`
+
+4. **Document & Proceed** (NOW)
+   - Document your plan in 3-5 bullet points as notes
+   - **Transition immediately** to implementation
+   - Use: `git-codemap transition implementation`
+
+## Decision Criteria
+
+**✅ Proceed when**: You know message types, actor boundaries, and test approach
+**❌ Don't wait for**: Perfect design or extensive documentation
+
+## Anti-Patterns
+
+- ❌ Over-designing for hypothetical future requirements
+- ❌ Creating extensive architecture documents
+- ❌ Waiting for review before starting implementation
+- ✅ Making pragmatic technical decisions
+- ✅ Documenting key choices with concise notes
+- ✅ Transitioning as soon as you have a plan
+
+

--- a/.codemap-checkout/context-discussion-stage.md
+++ b/.codemap-checkout/context-discussion-stage.md
@@ -1,0 +1,63 @@
+# Context: discussion-stage
+
+Context: discussion-stage
+Title: Discussion Stage Context
+Parent: project
+
+Content:
+# Discussion Stage - Understand & Decide
+
+**You are authorized to work autonomously. Don't wait for permission to proceed.**
+
+## Your Mission Right Now
+
+Understand what needs to be built well enough to design a solution. You have 10-20 minutes of thinking time - use it to get clear on the requirements, then move forward.
+
+## The Flow (Work Continuously)
+
+1. **Read & Research** (5-10 min)
+   - Read the bug description and any linked context
+   - Search the codebase for related code patterns
+   - Understand the "what" and "why" of this request
+
+2. **Clarify Blockers Only** (if needed)
+   - Only ask questions if you're genuinely blocked
+   - Make reasonable assumptions and document them with: `git-codemap note bug/name "assumption: ..."`
+   - Don't over-clarify - you can refine during architecture
+
+3. **Assess Scope** (2 min)
+   - Small (< 3 files)? Medium (3-10 files)? Large (> 10 files)?
+   - If large, consider splitting: create additional bugs for the pieces
+   - Document scope: `git-codemap note bug/name "scope: medium, affects X, Y, Z"`
+
+4. **Proceed Automatically** (NOW)
+   - Once you understand "what needs to change and why", you're done with discussion
+   - **Transition immediately** - don't ask permission
+   - Use: `git-codemap transition architecture`
+
+## Decision Criteria
+
+**✅ Proceed when**: You can explain the problem and what needs to change in 2-3 sentences
+**❌ Don't wait for**: Perfect requirements, detailed specs, or confirmation to move forward
+
+## Note-Taking: Be Concise, Be Frequent
+
+Use `git-codemap note bug/name "..."` to document:
+- Your understanding of the problem
+- Key assumptions you're making
+- Scope assessment (small/medium/large)
+- Any blockers or questions
+
+Keep notes short (1-2 sentences) but add them frequently as you learn.
+
+## Anti-Patterns
+
+- ❌ Asking "Should I move to architecture now?" - **just move**
+- ❌ Writing extensive requirement docs - **this is agile, keep moving**
+- ❌ Waiting for answers to every question - **document assumptions, proceed**
+- ✅ Making documented decisions and transitioning
+- ✅ Working continuously through stages
+- ✅ Asking only when truly blocked
+- ✅ Adding concise notes frequently
+
+

--- a/.codemap-checkout/context-implementation-stage.md
+++ b/.codemap-checkout/context-implementation-stage.md
@@ -1,0 +1,66 @@
+# Context: implementation-stage
+
+Context: implementation-stage
+Title: Implementation Stage Context
+Parent: project
+
+Content:
+# Implementation Stage - Build & Test
+
+**You are authorized to write code and make commits. Build it, test it, commit it.**
+
+## Your Mission Right Now
+
+Implement the functionality according to your design. Write tests alongside code. Make incremental commits. When core functionality works and tests pass, transition to comprehensive testing.
+
+## The Flow (Work Continuously)
+
+1. **Build Core Functionality** (main work)
+   - Implement according to your architecture plan
+   - Write unit tests as you go (not after)
+   - Make small, focused commits with clear messages
+   - Run tests frequently: `go test ./...`
+   - Run benchmarks when relevant: `go test -bench=. ./...`
+   - Document progress: `git-codemap note bug/name "implemented X, tests passing"`
+
+2. **Quality Checks** (continuous)
+   - Run formatter: `go fmt ./...`
+   - Fix issues immediately - don't accumulate tech debt
+   - Ensure code follows project patterns
+   - Use `decimal/` not floats for financial math
+   - Use `clocky.Now()` for mockable time
+
+3. **Actor-Specific Checklist** (for actor work)
+   - Message types are well-defined structs
+   - Actor handlers have clear input/output types
+   - Mailbox capacity is appropriate
+   - Tests inject messages directly (no mocking globals)
+
+4. **Proceed Automatically** (when ready)
+   - When core functionality works and tests pass, **transition immediately**
+   - Use: `git-codemap transition testing`
+
+## Decision Criteria
+
+**✅ Proceed when**: Core functionality implemented, unit tests passing, code is clean
+**❌ Don't wait for**: 100% test coverage, perfect refactoring, or approval
+
+## Note-Taking: Be Concise, Be Frequent
+
+Use `git-codemap note bug/name "..."` to document:
+- Progress on implementation ("implemented X, tests passing")
+- Issues encountered and resolutions
+- Design changes from original plan
+- Test coverage additions
+
+## Anti-Patterns
+
+- ❌ Using IEEE floats for financial calculations
+- ❌ Using `time.Now()` instead of `clocky.Now()`
+- ❌ Implementing without tests - **write tests alongside**
+- ❌ Waiting to commit until "everything is perfect" - **commit incrementally**
+- ✅ Making commits as you complete chunks of work
+- ✅ Running tests frequently
+- ✅ Using table-driven tests
+
+

--- a/.codemap-checkout/context-merge-stage.md
+++ b/.codemap-checkout/context-merge-stage.md
@@ -1,0 +1,79 @@
+# Context: merge-stage
+
+Context: merge-stage
+Title: Merge Stage Context
+Parent: project
+
+Content:
+# Merge Stage - Final Integration
+
+**You are authorized to prepare for integration. Check rebase status, verify quality, mark complete.**
+
+## Your Mission Right Now
+
+Final verification before marking ready for integration. Check if rebase is needed, ensure all tests still pass, then mark as complete for mergemeister integration.
+
+## The Flow (Work Continuously)
+
+1. **Check Integration Status** (verify)
+   - Check for upstream changes: `git-codemap check-rebase`
+   - Review status: `git-codemap bug status`
+   - Check for conflicts with other active bugs
+
+2. **Rebase If Needed** (if upstream changed)
+   - If upstream has new commits: `git rebase upstream`
+   - Resolve any conflicts carefully
+   - **Re-run full test suite** after rebase
+   - Ensure quality checks still pass
+   - Document: `git-codemap note bug/name "rebased on upstream, tests still pass"`
+
+3. **Final Verification** (thorough)
+   - Run complete test suite one final time
+   - Run all quality checks (linter, formatter)
+   - Review your changes: `git diff upstream`
+   - Verify acceptance criteria still met
+
+4. **Mark Complete** (automatic)
+   - All tests passing after rebase? ✅
+   - Quality checks clean? ✅
+   - No conflicts? ✅
+   - **Mark complete immediately**: `git-codemap transition complete`
+   - Mergemeister (separate LLM thread) handles actual integration
+
+## Decision Criteria
+
+**✅ Mark complete when**: Tests pass, quality clean, rebased if needed, no conflicts
+**❌ Don't wait for**: Manual approval, code review, or permission to mark complete
+
+## What Mergemeister Does
+
+Mergemeister is a separate LLM thread that handles integration:
+- Reviews completed bugs
+- Merges to upstream when appropriate
+- Handles any final integration issues
+- **Your job**: Get tests passing, mark complete, let mergemeister integrate
+
+## Note-Taking: Be Concise, Be Frequent
+
+Use `git-codemap note bug/name "..."` to document:
+- Rebase status ("rebased on upstream, no conflicts")
+- Final test results after rebase
+- Any integration issues discovered
+- Ready-for-merge confirmation
+
+Keep notes short (1-2 sentences) but add them frequently.
+
+## Anti-Patterns
+
+- ❌ Asking "Should I check for rebase?" - **check automatically**
+- ❌ Skipping rebase "because it's probably fine" - **always check**
+- ❌ Marking complete with failing tests - **tests must pass**
+- ❌ Trying to merge yourself - **let mergemeister handle it**
+- ❌ Waiting for permission to mark complete - **just mark it**
+- ✅ Checking rebase status automatically
+- ✅ Re-running tests after rebase
+- ✅ Documenting final status with notes
+- ✅ Marking complete when quality gates pass
+- ✅ Trusting mergemeister to handle integration
+
+

--- a/.codemap-checkout/context-project.md
+++ b/.codemap-checkout/context-project.md
@@ -1,0 +1,57 @@
+# Context: project
+
+Context: project
+Title: Project Context
+Parent: root
+
+Content:
+# Dropbear Development Standards
+
+## Commands
+```bash
+go fmt ./...           # Format code
+go test ./...          # Run tests
+go test -bench=. ./... # Run benchmarks
+# Never use `go build` - write tests instead
+```
+
+## Package Structure
+| Package | Purpose |
+|---------|---------|
+| `teddy/` | QuantConnect-like trading framework |
+| `cmd/spread/` | Main spread strategy (binance-coinbase arbitrage) |
+| `indicators/` | Technical indicators (EMA, MinMax, Intensity) |
+| `decimal/` | Fixed-point math (9 decimal places) |
+| `ds/` | Core data structures (Tick, Book, Lots) |
+| `orderbook/` | L2 order book with tree set |
+| `exchange/{coinbase,binance}/` | Exchange client libraries |
+
+## New Packages (Actor Architecture)
+| Package | Purpose |
+|---------|---------|
+| `actor/` | Actor framework (mailbox, routing) |
+| `msg/` | Message types (BinanceTick, SpreadSignal, etc.) |
+| `actors/` | Strategy actors (ingest, indicator, spread, risk) |
+| `iso/` | Categorical infrastructure (projections, laws) |
+
+## Code Style
+- Optimal time complexity for algorithms
+- Avoid dependencies (ask before introducing)
+- Never use IEEE floats for financial math - use `decimal/`
+- Use `clocky.Now()` for mockable time
+- Use `loggy.Fatalf()` for panic (raises SIGINT for cleanup)
+
+## Testing Strategy
+- Table-driven tests (see `decimal/decimal_test.go`)
+- Deterministic random seeds for reproducibility
+- Benchmarks for performance-critical code
+- Law verification tests for categorical properties
+
+## Havequick Reference
+Patterns to port from `~/src/havequick/`:
+- `platform/runtime/actor.zig` - Actor with compile-time handler discovery
+- `platform/mailbox/mailbox.zig` - Ring buffer with overflow tracking
+- `lib/uberparser/iso/groupoid.zig` - Projections and morphisms
+- `lib/uberparser/iso/category.zig` - Law verification
+
+

--- a/.codemap-checkout/context-root.md
+++ b/.codemap-checkout/context-root.md
@@ -1,0 +1,32 @@
+# Context: root
+
+Context: root
+Title: Root Context
+
+Content:
+# Dropbear: High-Frequency Crypto Trading System
+
+This project uses Codemap for workflow coordination. All guidance is automatically composed from context files and injected into your AI assistant's prompt.
+
+## The Core Thesis
+Binance BTCFDUSD trades predict Coinbase BTC-USD by ~600ms. We exploit this latency arbitrage using:
+- **penny** - AWS z1d 1ms from Coinbase in us-east-1
+- **nickel** - AWS z1d in Tokyo for 21ms faster Binance data
+
+## Current Investigation
+We're applying havequick's categorical cross-validation framework to formally model and improve the spread strategy:
+- Actor decomposition (message-passing with explicit mailboxes)
+- Categorical law verification (monoid/groupoid properties)
+- Shadow mode (run Zig alongside Go, compare signals)
+
+## How This Works
+- Context is assembled from: ROOT → PROJECT → STAGE → BUG
+- Reference havequick patterns at `~/src/havequick/`
+- Plan file: `~/.claude/plans/noble-plotting-biscuit.md`
+
+## Getting Help
+- `git-codemap wtf` - See current context and quick commands
+- `git-codemap list bugs` - See all tracked work
+- `git-codemap transition <stage>` - Move to next workflow stage
+
+

--- a/.codemap-checkout/context-testing-stage.md
+++ b/.codemap-checkout/context-testing-stage.md
@@ -1,0 +1,70 @@
+# Context: testing-stage
+
+Context: testing-stage
+Title: Testing Stage Context
+Parent: project
+
+Content:
+# Testing Stage - Verify Quality
+
+**You are authorized to verify quality and transition when tests pass. Run everything, fix issues, proceed.**
+
+## Your Mission Right Now
+
+Run comprehensive tests, verify quality, fix any issues. When everything passes, transition to merge stage automatically.
+
+## The Flow (Work Continuously)
+
+1. **Run Full Test Suite** (comprehensive)
+   - Execute complete test suite: `go test ./...`
+   - Run benchmarks: `go test -bench=. ./...`
+   - Run backtests if applicable: `go run ./cmd/spread -backtest chaos -symbol BTC`
+   - Check for regressions in existing functionality
+
+2. **Quality Verification** (thorough)
+   - Run formatter: `go fmt ./...`
+   - Verify acceptance criteria from discussion phase
+   - Check that decimal math is used (not floats)
+   - Verify time is mockable (clocky.Now)
+
+3. **Actor/Categorical Testing** (for actor work)
+   - Law verification tests pass (monoid, groupoid laws)
+   - Cross-validation tests pass (implementations agree)
+   - Mailbox overflow behavior is correct
+   - Message types serialize/deserialize correctly
+
+4. **Shadow Mode Testing** (for strategy work)
+   - Go and Zig/actor implementations produce same signals
+   - Track agreement rate across test datasets
+   - Document any discrepancies
+
+5. **Proceed Automatically** (when clean)
+   - All tests passing? ✅
+   - Quality checks clean? ✅
+   - Feature works as expected? ✅
+   - **Transition immediately**: `git-codemap transition merge`
+
+## Decision Criteria
+
+**✅ Proceed when**: All tests pass, quality checks clean, feature works correctly
+**❌ Don't wait for**: Additional review, permission, or documentation updates
+
+## Test Commands
+
+```bash
+go test ./...                          # Unit tests
+go test -bench=. ./...                 # Benchmarks
+go test -v -run TestLaws ./iso/...     # Law verification
+./scripts/test.sh spread               # Backtest suite
+```
+
+## Anti-Patterns
+
+- ❌ Skipping backtest verification
+- ❌ Ignoring law verification test failures
+- ❌ Transitioning with failing tests "to fix later"
+- ✅ Running comprehensive quality checks
+- ✅ Fixing issues immediately when found
+- ✅ Transitioning automatically when clean
+
+

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,144 @@
+# Buy Gap Protection Architecture
+
+## Problem Statement
+
+Current buy gap protection has two issues:
+1. **Decay function is ineffective** - Median time-since-sell is 0s, so exponential decay rarely helps
+2. **No visibility into gap behavior** - Can't measure effectiveness in real trading
+
+## Proposed Changes
+
+### 1. Add Linear Decay Option (IMPLEMENT)
+
+**Rationale**: Exponential decay `e^(-t/period)` decays slowly at first, then rapidly. For very short time scales (<1s typical), linear decay `max(0, 1-t/period)` is more predictable and easier to reason about.
+
+**Implementation**:
+- Add new flag: `-decay-mode={exponential,linear,none}`
+- Default to `exponential` (backward compatible)
+- Linear formula: `decayFactor = max(0, 1 - timeSinceSell/decayPeriod)`
+- None: `decayFactor = 1` (full gap protection always)
+
+**Code location**: `cmd/spread/main.go:399-411`
+
+### 2. Add Gap Metrics Tracking (IMPLEMENT)
+
+**Rationale**: Need runtime visibility into how gap protection performs.
+
+**Implementation**:
+- Track counters in global state:
+  - `gapSignalsTotal` - total buy signals evaluated
+  - `gapSignalsBlocked` - signals blocked by gap
+  - `gapSignalsExecuted` - signals that passed gap check
+- Log summary periodically (every 1000 signals or 5 minutes)
+- Include in existing verbose logging
+
+**Code location**:
+- Counters: Add near `gHolding` declarations
+- Increment: Lines 417-430
+- Logging: Add periodic summary
+
+### 3. Enhance Analyzer with Decay Comparison (IMPLEMENT)
+
+**Rationale**: Need to empirically test which decay mode works best.
+
+**Implementation**:
+- Extend `cmd/buygap` to simulate all three decay modes simultaneously
+- Compare block rates and gap distributions
+- Report which mode allows more/fewer buys
+
+### 4. Add Per-Symbol Gap Configuration (DEFER)
+
+**Rationale**: DOGE needs different gap than BTC (lower volatility).
+
+**Implementation**: NOT implementing in this phase - needs broader config system refactor. Document as future work.
+
+## Architecture Decisions
+
+### Decision 1: Backward Compatibility
+**Choice**: Default to `exponential` decay mode, same as current behavior.
+**Rationale**: Don't break existing trading behavior. Allow opt-in testing of new modes.
+
+### Decision 2: Decay Mode Options
+**Choices**:
+- `exponential`: Current behavior `e^(-timeRatio*periodScale)`
+- `linear`: New `max(0, 1-timeRatio)`
+- `none`: No decay (constant gap protection)
+
+**Rationale**:
+- Exponential: Maintain backward compat
+- Linear: Better for short time scales
+- None: Simplest, may be best given signals cluster so tightly
+
+### Decision 3: No Breaking Changes to Flags
+**Choice**: Add new `-decay-mode` flag, keep existing `-decay` flag unchanged.
+**Rationale**: Existing scripts and backtests continue to work.
+
+## Implementation Plan
+
+### Phase 1: Core Changes (THIS ITERATION)
+1. Add `DecayMode` flag to `cmd/spread/main.go`
+2. Refactor decay calculation into separate function
+3. Implement linear and none modes
+4. Add gap metrics tracking
+5. Add periodic metrics logging
+
+### Phase 2: Enhanced Analyzer (THIS ITERATION)
+1. Extend `cmd/buygap` to test all decay modes
+2. Add comparative analysis output
+3. Run across multiple datasets
+
+### Phase 3: Testing & Validation (THIS ITERATION)
+1. Run `go test ./...`
+2. Run analyzer on chaos/BTC with all three modes
+3. Compare backtest results: `./scripts/test.sh spread -buygap 5 -decay-mode linear`
+4. Document findings
+
+### Phase 4: Future Work (NOT THIS ITERATION)
+- Per-symbol gap configuration
+- Volume-based decay
+- Adaptive gap based on realized volatility
+
+## Testing Strategy
+
+### Unit Tests
+- Test decay function with known inputs
+- Verify linear decay reaches 0 at period
+- Verify exponential matches current behavior
+- Verify none mode always returns 1
+
+### Integration Tests
+- Run analyzer on existing datasets
+- Verify backward compatibility (default exponential matches current)
+- Compare metrics across decay modes
+
+### Backtest Validation
+- Run spread strategy with each decay mode
+- Compare sharpe, profit, buy counts
+- Ensure no regressions
+
+## Success Criteria
+
+1. ✅ All tests pass (`go test ./...`)
+2. ✅ Backward compatible (default behavior unchanged)
+3. ✅ New modes available via flag
+4. ✅ Metrics tracking works
+5. ✅ Analyzer enhanced with comparison
+6. ✅ Documentation complete
+
+## Files to Modify
+
+1. `cmd/spread/main.go` - Add decay mode flag and refactor calculation
+2. `cmd/buygap/main.go` - Add multi-mode comparison
+3. `BUYGAP_ANALYSIS.md` - Update with implementation notes
+4. New: `cmd/spread/buygap.go` - Extract gap logic for testability
+
+## Risks & Mitigations
+
+**Risk**: New decay modes perform worse than exponential
+**Mitigation**: Default to exponential, only opt-in to new modes
+
+**Risk**: Metrics tracking adds latency
+**Mitigation**: Simple counter increments, minimal overhead
+
+**Risk**: Breaking backward compatibility
+**Mitigation**: Extensive testing, default to current behavior

--- a/BUYGAP_ANALYSIS.md
+++ b/BUYGAP_ANALYSIS.md
@@ -1,0 +1,156 @@
+# Buy Gap Protection Analysis
+
+## Summary
+
+The buy gap protection is **extremely aggressive**, blocking 90% of buy signals for BTC and 98% for DOGE. The decay function has minimal practical effect because the median time between sell and next buy signal is effectively 0 seconds.
+
+## Tool Created
+
+`cmd/buygap/main.go` - Analyzer for buy gap protection effectiveness
+
+Usage:
+```bash
+go run ./cmd/buygap -dataset chaos -symbol BTC
+go run ./cmd/buygap -dataset chaos -symbol BTC -buygap 3
+go run ./cmd/buygap -dataset chaos -symbol BTC -decay 60s
+```
+
+## Key Findings
+
+### 1. Gap Protection is Very Restrictive
+
+**BTC (buygap=5bps, decay=30s):**
+- Total buy signals: 10,578
+- Executed: 1,077 (10.2%)
+- Blocked: 9,501 (89.8%)
+
+**DOGE (buygap=3bps, decay=30s):**
+- Total buy signals: 87,187
+- Executed: 1,645 (1.9%)
+- Blocked: 85,542 (98.1%)
+
+The gap protection is working as designed - preventing accumulation of lots at similar prices. However, it may be **too aggressive**, especially for DOGE.
+
+### 2. Decay Factor Has Minimal Effect
+
+**Time Since Last Sell Distribution:**
+- Median (P50): 0.0s
+- P95: 0.4s
+- Max: 1.0s
+
+The decay mechanism assumes there will be substantial time between sells and subsequent buy signals, but in practice:
+- Buy signals cluster very tightly in time
+- Most new buy signals occur within milliseconds of the last sell
+- The exponential decay `e^(-timeRatio*periodScale)` rarely has time to decay significantly
+
+**Decay Factor Distribution:**
+- Mean: 0.43
+- Median: 0.42
+- This shows the decay is active, but the low time-since-sell means it doesn't help much
+
+### 3. Inventory Scaling Works But Rarely Maxes Out
+
+**Inventory Scale Distribution (BTC):**
+- Mean: 1.17x
+- Median: 1.02x
+- Max: 2.00x (at 100% of target)
+
+The inventory scaling (1 + inventory/target) successfully increases the gap as position grows:
+- Early phase (<25% inventory): 90.4% blocked
+- Over target (>100%): 100% blocked
+
+However, most of the time the bot operates at low inventory levels, so scaling has limited impact.
+
+### 4. Actual Gap vs Required Gap
+
+**For Blocked Signals (BTC, buygap=5bps):**
+- Actual gap median: -2.37bps (price is 2.37bps ABOVE last buy, not below)
+- Required gap median: 2.56bps
+- This means most blocked signals are trying to buy at nearly the same price or higher
+
+The negative actual gaps show the gap protection is correctly preventing "ratchet buys" where we'd accumulate at progressively higher prices.
+
+## Parameter Sensitivity
+
+### Varying Buy Gap (BTC, decay=30s)
+
+| Buy Gap | Executed | Blocked | Block Rate |
+|---------|----------|---------|------------|
+| 3bps    | ~1100    | ~9500   | ~89%       |
+| 5bps    | 1077     | 9501    | 89.8%      |
+| 7bps    | 1031     | 9547    | 90.3%      |
+
+**Finding**: Block rate is relatively insensitive to gap size (89-90%). The gap size matters more for the *quality* of trades than quantity.
+
+### Varying Decay Period (BTC, buygap=5bps)
+
+| Decay   | Executed | Blocked | Block Rate |
+|---------|----------|---------|------------|
+| 30s     | 1077     | 9501    | 89.8%      |
+| 60s     | 781      | 9797    | 92.6%      |
+
+**Finding**: Longer decay period → MORE blocking (because decay factor stays higher longer). But given time-since-sell is so low, this effect is minimal.
+
+## Recommendations
+
+### 1. Investigate Signal Clustering
+
+**Problem**: Median time-since-sell is 0s, which suggests buy signals occur in rapid bursts immediately after sells.
+
+**Possible causes:**
+- Market oscillates rapidly around spread threshold
+- Spread EMA lags behind actual spread, creating false signals
+- Binance-Coinbase spread mean-reverts very quickly
+
+**Action**: Add temporal analysis to understand signal timing patterns.
+
+### 2. Consider Alternative Decay Functions
+
+Current decay is exponential: `e^(-timeRatio*periodScale)`
+
+Given the very short time scales, consider:
+- **Linear decay**: `max(0, 1 - timeRatio/period)` - simpler and more predictable
+- **Step function**: Full protection for first N seconds, then off
+- **No decay**: If signals cluster this tightly, decay may not be useful
+
+### 3. Reduce Gap for Lower Volatility Coins
+
+**DOGE blocks 98% of signals** - may be too restrictive.
+
+Consider:
+- DOGE: buygap = 2-3bps (currently uses same 5bps as BTC)
+- Or: Scale gap by coin volatility (use ATR or realized vol)
+
+### 4. Gap Effectiveness is Good
+
+The gap **is working correctly** to prevent ratchet buys:
+- Median actual gap is negative (trying to buy higher than last buy)
+- 90% block rate shows strong protection
+- Inventory scaling increases protection as position grows
+
+**Don't remove it** - it's preventing bad behavior. Question is whether it's *too strong*.
+
+### 5. Consider Volume-Based Protection
+
+Alternative to time-based decay: decay based on volume traded since last sell.
+- More volume = more mean reversion = safer to buy again
+- Less sensitive to microsecond-level timing
+
+## Code References
+
+**Buy gap logic**: `cmd/spread/main.go:381-434`
+- Lines 393-397: Inventory scaling
+- Lines 399-411: Decay calculation
+- Lines 413-431: Gap check and blocking
+
+**Flags**:
+- `flagBuyGap`: Line 34 (default 5bps)
+- `flagBuyDecay`: Line 35 (default 30s)
+- `flagTarget`: Line 28 (default $5000)
+
+## Next Steps
+
+1. Add temporal clustering analysis to understand why time-since-sell is so low
+2. Run backtest comparison: buygap={3,5,7,10} across multiple datasets
+3. Consider implementing linear decay or removing decay entirely
+4. Test volume-based decay as alternative to time-based

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
-# dropbear coding guidelines
+# Dropbear Development Guide
 
-this project does high frequency trading of crypto.
+## The Core Thesis
+
+This project does high frequency trading of crypto. We believe **Binance BTCFDUSD trades predict Coinbase BTC-USD by ~600ms**. We exploit this latency arbitrage using superior market intelligence and telecommunications.
 
 we have an aws z1d instance 1ms away from coinbase in us-east-1 named penny.
 
@@ -195,3 +197,29 @@ spread weekend    ETH  vol= 0.35 profit=   -6.35 sharpe=  -4.91 buys= 40 sells= 
 spread weekend    SOL  vol= 0.19 profit=    0.74 sharpe=  -4.78 buys= 23 sells=  0 invested=  978 bad
 total n=44 volume=0.75 profit=-26.67 (vs. -403.03) sharpe=+3.95 (vs. -10.48) invested=1489 | GREAT=18 good=14 loco=3 bad=9
 ```
+
+## Current Investigation: Categorical Decomposition
+
+We're applying havequick's categorical cross-validation framework to formally model and improve the spread strategy:
+
+- **Actor decomposition**: Message-passing with explicit mailboxes (no shared mutable state)
+- **Categorical law verification**: Monoid/groupoid properties for trading operations
+- **Shadow mode**: Run new implementation alongside Go, compare signals without executing
+
+Reference patterns at `~/src/havequick/`:
+- `platform/runtime/actor.zig` - Actor with compile-time handler discovery
+- `platform/mailbox/mailbox.zig` - Ring buffer with overflow tracking
+- `lib/uberparser/iso/groupoid.zig` - Projections and morphisms
+
+Plan file: `~/.claude/plans/noble-plotting-biscuit.md`
+
+## Git Codemap Workflow
+
+```bash
+git-codemap list bugs              # List open bugs
+git-codemap work <oid>             # Open worktree + Claude session
+git-codemap wtf                    # Quick context: bug, station, git status
+git-codemap transition implement   # Move to next stage
+```
+
+Stages: **plan** → **implement** → **review** → **closed**

--- a/actor/actor.go
+++ b/actor/actor.go
@@ -1,0 +1,145 @@
+package actor
+
+import (
+	"log"
+	"sync/atomic"
+)
+
+// Message is the interface all actor messages must implement.
+// Empty interface allows any type to be a message.
+type Message interface{}
+
+// Handler processes incoming messages and produces outgoing messages.
+// This is the core computation unit in the actor model.
+type Handler[In, Out any] interface {
+	// Handle processes an incoming message and returns zero or more output messages.
+	Handle(msg In) []Out
+}
+
+// HandlerFunc is a function adapter for Handler.
+type HandlerFunc[In, Out any] func(msg In) []Out
+
+func (f HandlerFunc[In, Out]) Handle(msg In) []Out {
+	return f(msg)
+}
+
+// Actor is a message-processing unit with its own mailbox.
+// Messages are received via the mailbox and dispatched to a handler.
+type Actor[In, Out any] struct {
+	ID       uint64
+	mailbox  *MutexMailbox[In]
+	handler  Handler[In, Out]
+	router   Router[Out]
+	running  atomic.Bool
+	capacity int
+}
+
+// Router delivers output messages to their destinations.
+type Router[T any] interface {
+	Route(msg T)
+}
+
+// RouterFunc is a function adapter for Router.
+type RouterFunc[T any] func(msg T)
+
+func (f RouterFunc[T]) Route(msg T) {
+	f(msg)
+}
+
+// NullRouter discards all messages (useful for testing).
+type NullRouter[T any] struct{}
+
+func (NullRouter[T]) Route(msg T) {}
+
+// Config configures actor creation.
+type Config struct {
+	ID       uint64
+	Capacity int // mailbox capacity, default 1000
+}
+
+// NewActor creates a new actor with the given handler and optional router.
+func NewActor[In, Out any](handler Handler[In, Out], router Router[Out], cfg Config) *Actor[In, Out] {
+	capacity := cfg.Capacity
+	if capacity <= 0 {
+		capacity = 1000
+	}
+	return &Actor[In, Out]{
+		ID:       cfg.ID,
+		mailbox:  NewMutexMailbox[In](capacity),
+		handler:  handler,
+		router:   router,
+		capacity: capacity,
+	}
+}
+
+// Send adds a message to the actor's mailbox.
+func (a *Actor[In, Out]) Send(msg In) {
+	a.mailbox.Push(msg)
+}
+
+// Step processes a single message from the mailbox.
+// Returns true if a message was processed, false if mailbox was empty.
+// This is useful for single-threaded or event-loop based processing.
+func (a *Actor[In, Out]) Step() bool {
+	result := a.mailbox.Pop()
+	if result == nil {
+		return false
+	}
+
+	// Log dropped messages if any
+	if result.DroppedSinceLastRead > 0 {
+		log.Printf("[actor %d] dropped %d messages", a.ID, result.DroppedSinceLastRead)
+	}
+
+	// Process message and route outputs
+	outputs := a.handler.Handle(result.Message)
+	for _, out := range outputs {
+		if a.router != nil {
+			a.router.Route(out)
+		}
+	}
+
+	return true
+}
+
+// Run processes messages continuously until Stop is called.
+// This should be called in its own goroutine.
+func (a *Actor[In, Out]) Run() {
+	a.running.Store(true)
+	for a.running.Load() {
+		if !a.Step() {
+			// No message available, could add backoff here
+			// For now, just spin (caller should use Step() for control)
+		}
+	}
+}
+
+// Stop signals the actor to stop processing.
+func (a *Actor[In, Out]) Stop() {
+	a.running.Store(false)
+}
+
+// IsRunning returns true if the actor is running.
+func (a *Actor[In, Out]) IsRunning() bool {
+	return a.running.Load()
+}
+
+// Len returns the number of messages in the mailbox.
+func (a *Actor[In, Out]) Len() int {
+	return a.mailbox.Len()
+}
+
+// IsEmpty returns true if the mailbox is empty.
+func (a *Actor[In, Out]) IsEmpty() bool {
+	return a.mailbox.IsEmpty()
+}
+
+// Drain processes all messages currently in the mailbox.
+// Returns the number of messages processed.
+func (a *Actor[In, Out]) Drain() int {
+	count := 0
+	for a.Step() {
+		count++
+	}
+	return count
+}

--- a/actor/actor_test.go
+++ b/actor/actor_test.go
@@ -1,0 +1,257 @@
+package actor
+
+import (
+	"sync"
+	"testing"
+)
+
+type incrementHandler struct {
+	processed int
+}
+
+func (h *incrementHandler) Handle(msg int) []int {
+	h.processed++
+	return []int{msg + 1}
+}
+
+type collectRouter struct {
+	mu       sync.Mutex
+	messages []int
+}
+
+func (r *collectRouter) Route(msg int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.messages = append(r.messages, msg)
+}
+
+func (r *collectRouter) Get() []int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]int{}, r.messages...)
+}
+
+func TestActor_SendAndStep(t *testing.T) {
+	handler := &incrementHandler{}
+	router := &collectRouter{}
+	actor := NewActor[int, int](handler, router, Config{ID: 1})
+
+	// Send messages
+	actor.Send(1)
+	actor.Send(2)
+	actor.Send(3)
+
+	if actor.Len() != 3 {
+		t.Errorf("expected 3 messages, got %d", actor.Len())
+	}
+
+	// Process one message
+	if !actor.Step() {
+		t.Error("expected Step to return true")
+	}
+	if handler.processed != 1 {
+		t.Errorf("expected 1 processed, got %d", handler.processed)
+	}
+
+	msgs := router.Get()
+	if len(msgs) != 1 || msgs[0] != 2 {
+		t.Errorf("expected [2], got %v", msgs)
+	}
+
+	// Process remaining
+	actor.Drain()
+	if handler.processed != 3 {
+		t.Errorf("expected 3 processed, got %d", handler.processed)
+	}
+
+	msgs = router.Get()
+	if len(msgs) != 3 {
+		t.Errorf("expected 3 routed, got %d", len(msgs))
+	}
+}
+
+func TestActor_EmptyStep(t *testing.T) {
+	handler := &incrementHandler{}
+	actor := NewActor[int, int](handler, NullRouter[int]{}, Config{ID: 1})
+
+	if actor.Step() {
+		t.Error("expected Step to return false on empty mailbox")
+	}
+	if handler.processed != 0 {
+		t.Error("expected no messages processed")
+	}
+}
+
+func TestActor_Drain(t *testing.T) {
+	handler := &incrementHandler{}
+	router := &collectRouter{}
+	actor := NewActor[int, int](handler, router, Config{ID: 1})
+
+	// Send 10 messages
+	for i := 0; i < 10; i++ {
+		actor.Send(i)
+	}
+
+	// Drain all
+	count := actor.Drain()
+	if count != 10 {
+		t.Errorf("expected 10 drained, got %d", count)
+	}
+	if !actor.IsEmpty() {
+		t.Error("expected empty after drain")
+	}
+
+	msgs := router.Get()
+	if len(msgs) != 10 {
+		t.Errorf("expected 10 routed, got %d", len(msgs))
+	}
+}
+
+func TestActor_HandlerFunc(t *testing.T) {
+	// Test using HandlerFunc adapter
+	handler := HandlerFunc[int, int](func(msg int) []int {
+		return []int{msg * 2}
+	})
+	router := &collectRouter{}
+	actor := NewActor[int, int](handler, router, Config{ID: 1})
+
+	actor.Send(5)
+	actor.Step()
+
+	msgs := router.Get()
+	if len(msgs) != 1 || msgs[0] != 10 {
+		t.Errorf("expected [10], got %v", msgs)
+	}
+}
+
+func TestActor_NoOutputs(t *testing.T) {
+	// Handler that produces no outputs
+	handler := HandlerFunc[int, int](func(msg int) []int {
+		return nil
+	})
+	router := &collectRouter{}
+	actor := NewActor[int, int](handler, router, Config{ID: 1})
+
+	actor.Send(1)
+	actor.Step()
+
+	msgs := router.Get()
+	if len(msgs) != 0 {
+		t.Errorf("expected no messages, got %v", msgs)
+	}
+}
+
+func TestActor_MultipleOutputs(t *testing.T) {
+	// Handler that produces multiple outputs
+	handler := HandlerFunc[int, int](func(msg int) []int {
+		return []int{msg, msg * 2, msg * 3}
+	})
+	router := &collectRouter{}
+	actor := NewActor[int, int](handler, router, Config{ID: 1})
+
+	actor.Send(5)
+	actor.Step()
+
+	msgs := router.Get()
+	if len(msgs) != 3 {
+		t.Errorf("expected 3 messages, got %d", len(msgs))
+	}
+	expected := []int{5, 10, 15}
+	for i, m := range expected {
+		if msgs[i] != m {
+			t.Errorf("expected msgs[%d]=%d, got %d", i, m, msgs[i])
+		}
+	}
+}
+
+func TestActor_NilRouter(t *testing.T) {
+	handler := HandlerFunc[int, int](func(msg int) []int {
+		return []int{msg + 1}
+	})
+	actor := NewActor[int, int](handler, nil, Config{ID: 1})
+
+	actor.Send(1)
+	// Should not panic with nil router
+	actor.Step()
+}
+
+func TestActor_DefaultCapacity(t *testing.T) {
+	handler := HandlerFunc[int, int](func(msg int) []int { return nil })
+	actor := NewActor[int, int](handler, nil, Config{ID: 1})
+
+	if actor.capacity != 1000 {
+		t.Errorf("expected default capacity 1000, got %d", actor.capacity)
+	}
+}
+
+func TestActor_CustomCapacity(t *testing.T) {
+	handler := HandlerFunc[int, int](func(msg int) []int { return nil })
+	actor := NewActor[int, int](handler, nil, Config{ID: 1, Capacity: 50})
+
+	if actor.capacity != 50 {
+		t.Errorf("expected capacity 50, got %d", actor.capacity)
+	}
+}
+
+type stringMsg struct {
+	Text string
+}
+
+type upperHandler struct{}
+
+func (h upperHandler) Handle(msg stringMsg) []stringMsg {
+	return []stringMsg{{Text: "UPPER:" + msg.Text}}
+}
+
+func TestActor_CustomMessageTypes(t *testing.T) {
+	router := &struct {
+		mu   sync.Mutex
+		msgs []stringMsg
+	}{}
+	routerFn := RouterFunc[stringMsg](func(msg stringMsg) {
+		router.mu.Lock()
+		defer router.mu.Unlock()
+		router.msgs = append(router.msgs, msg)
+	})
+
+	actor := NewActor[stringMsg, stringMsg](upperHandler{}, routerFn, Config{ID: 1})
+
+	actor.Send(stringMsg{Text: "hello"})
+	actor.Step()
+
+	router.mu.Lock()
+	if len(router.msgs) != 1 || router.msgs[0].Text != "UPPER:hello" {
+		t.Errorf("expected UPPER:hello, got %v", router.msgs)
+	}
+	router.mu.Unlock()
+}
+
+func BenchmarkActor_SendStep(b *testing.B) {
+	handler := HandlerFunc[int, int](func(msg int) []int {
+		return []int{msg + 1}
+	})
+	actor := NewActor[int, int](handler, NullRouter[int]{}, Config{ID: 1, Capacity: 10000})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		actor.Send(i)
+		actor.Step()
+	}
+}
+
+func BenchmarkActor_Batch(b *testing.B) {
+	handler := HandlerFunc[int, int](func(msg int) []int {
+		return []int{msg + 1}
+	})
+	actor := NewActor[int, int](handler, NullRouter[int]{}, Config{ID: 1, Capacity: 10000})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Send batch
+		for j := 0; j < 100; j++ {
+			actor.Send(j)
+		}
+		// Drain batch
+		actor.Drain()
+	}
+}

--- a/actor/mailbox.go
+++ b/actor/mailbox.go
@@ -1,0 +1,117 @@
+// Package actor provides a message-passing actor framework with mailboxes.
+// Ported from havequick/platform/mailbox/mailbox.zig patterns.
+package actor
+
+import "sync"
+
+// ReadResult contains a message and the count of messages dropped since the last read.
+// This allows actors to detect backpressure and log overflow conditions.
+type ReadResult[T any] struct {
+	Message              T
+	DroppedSinceLastRead uint64
+}
+
+// Mailbox is a ring buffer for actor messages with overflow tracking.
+// Fixed-capacity ring buffer that drops messages when full and tracks
+// the count of dropped messages.
+type Mailbox[T any] struct {
+	buffer       []T
+	readIdx      int
+	writeIdx     int
+	count        int
+	droppedCount uint64
+	capacity     int
+}
+
+// NewMailbox creates a new mailbox with the given capacity.
+func NewMailbox[T any](capacity int) *Mailbox[T] {
+	return &Mailbox[T]{
+		buffer:   make([]T, capacity),
+		capacity: capacity,
+	}
+}
+
+// Push adds a message to the mailbox.
+// If the mailbox is full, the message is dropped and droppedCount is incremented.
+func (m *Mailbox[T]) Push(msg T) {
+	if m.count >= m.capacity {
+		m.droppedCount++
+		return
+	}
+	m.buffer[m.writeIdx] = msg
+	m.writeIdx = (m.writeIdx + 1) % m.capacity
+	m.count++
+}
+
+// Pop removes and returns the next message from the mailbox.
+// Returns nil if the mailbox is empty.
+// The returned ReadResult includes the dropped_since_last_read count,
+// which is reset to 0 after being reported.
+func (m *Mailbox[T]) Pop() *ReadResult[T] {
+	if m.count == 0 {
+		return nil
+	}
+	msg := m.buffer[m.readIdx]
+	m.readIdx = (m.readIdx + 1) % m.capacity
+	m.count--
+	dropped := m.droppedCount
+	m.droppedCount = 0
+	return &ReadResult[T]{
+		Message:              msg,
+		DroppedSinceLastRead: dropped,
+	}
+}
+
+// Len returns the current number of messages in the mailbox.
+func (m *Mailbox[T]) Len() int {
+	return m.count
+}
+
+// IsEmpty returns true if the mailbox has no messages.
+func (m *Mailbox[T]) IsEmpty() bool {
+	return m.count == 0
+}
+
+// MutexMailbox wraps a Mailbox with a mutex for thread-safe access.
+// Use this when multiple goroutines need to push to the same mailbox.
+type MutexMailbox[T any] struct {
+	inner *Mailbox[T]
+	mu    sync.Mutex
+}
+
+// NewMutexMailbox creates a new thread-safe mailbox with the given capacity.
+func NewMutexMailbox[T any](capacity int) *MutexMailbox[T] {
+	return &MutexMailbox[T]{
+		inner: NewMailbox[T](capacity),
+	}
+}
+
+// Push adds a message to the mailbox (thread-safe).
+// If the mailbox is full, the message is dropped and droppedCount is incremented.
+func (m *MutexMailbox[T]) Push(msg T) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.inner.Push(msg)
+}
+
+// Pop removes and returns the next message from the mailbox (thread-safe).
+// Returns nil if the mailbox is empty.
+func (m *MutexMailbox[T]) Pop() *ReadResult[T] {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.inner.Pop()
+}
+
+// Len returns the current number of messages in the mailbox (thread-safe).
+func (m *MutexMailbox[T]) Len() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.inner.Len()
+}
+
+// IsEmpty returns true if the mailbox has no messages (thread-safe).
+func (m *MutexMailbox[T]) IsEmpty() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.inner.IsEmpty()
+}

--- a/actor/mailbox_test.go
+++ b/actor/mailbox_test.go
@@ -1,0 +1,308 @@
+package actor
+
+import (
+	"sync"
+	"testing"
+)
+
+type testMessage struct {
+	ID    int
+	Value int
+}
+
+func TestMailbox_PushPop(t *testing.T) {
+	mb := NewMailbox[testMessage](4)
+
+	// Push messages
+	mb.Push(testMessage{ID: 1, Value: 100})
+	mb.Push(testMessage{ID: 2, Value: 200})
+
+	// Pop first message
+	result := mb.Pop()
+	if result == nil {
+		t.Fatal("expected message, got nil")
+	}
+	if result.Message.ID != 1 || result.Message.Value != 100 {
+		t.Errorf("expected {1, 100}, got {%d, %d}", result.Message.ID, result.Message.Value)
+	}
+	if result.DroppedSinceLastRead != 0 {
+		t.Errorf("expected 0 dropped, got %d", result.DroppedSinceLastRead)
+	}
+
+	// Pop second message
+	result = mb.Pop()
+	if result == nil {
+		t.Fatal("expected message, got nil")
+	}
+	if result.Message.ID != 2 || result.Message.Value != 200 {
+		t.Errorf("expected {2, 200}, got {%d, %d}", result.Message.ID, result.Message.Value)
+	}
+
+	// Should be empty
+	result = mb.Pop()
+	if result != nil {
+		t.Errorf("expected nil, got message")
+	}
+}
+
+func TestMailbox_Empty(t *testing.T) {
+	mb := NewMailbox[testMessage](10)
+	if !mb.IsEmpty() {
+		t.Error("new mailbox should be empty")
+	}
+	if mb.Len() != 0 {
+		t.Errorf("new mailbox len should be 0, got %d", mb.Len())
+	}
+	result := mb.Pop()
+	if result != nil {
+		t.Error("pop from empty mailbox should return nil")
+	}
+}
+
+func TestMailbox_Overflow(t *testing.T) {
+	mb := NewMailbox[testMessage](2)
+
+	// Fill to capacity
+	mb.Push(testMessage{ID: 1, Value: 100})
+	mb.Push(testMessage{ID: 2, Value: 200})
+
+	// These should be dropped
+	mb.Push(testMessage{ID: 3, Value: 300})
+	mb.Push(testMessage{ID: 4, Value: 400})
+	mb.Push(testMessage{ID: 5, Value: 500})
+
+	// Pop first - should report 3 dropped
+	result := mb.Pop()
+	if result == nil {
+		t.Fatal("expected message, got nil")
+	}
+	if result.Message.ID != 1 {
+		t.Errorf("expected ID 1, got %d", result.Message.ID)
+	}
+	if result.DroppedSinceLastRead != 3 {
+		t.Errorf("expected 3 dropped, got %d", result.DroppedSinceLastRead)
+	}
+
+	// Pop second - dropped count should be reset
+	result = mb.Pop()
+	if result == nil {
+		t.Fatal("expected message, got nil")
+	}
+	if result.Message.ID != 2 {
+		t.Errorf("expected ID 2, got %d", result.Message.ID)
+	}
+	if result.DroppedSinceLastRead != 0 {
+		t.Errorf("expected 0 dropped after reset, got %d", result.DroppedSinceLastRead)
+	}
+}
+
+func TestMailbox_DroppedCounterReset(t *testing.T) {
+	mb := NewMailbox[testMessage](1)
+
+	// Fill mailbox
+	mb.Push(testMessage{ID: 1, Value: 100})
+
+	// Drop some messages
+	mb.Push(testMessage{ID: 2, Value: 200})
+	mb.Push(testMessage{ID: 3, Value: 300})
+
+	// Pop - should report 2 dropped
+	result := mb.Pop()
+	if result == nil {
+		t.Fatal("expected message")
+	}
+	if result.DroppedSinceLastRead != 2 {
+		t.Errorf("expected 2 dropped, got %d", result.DroppedSinceLastRead)
+	}
+
+	// Add more messages
+	mb.Push(testMessage{ID: 4, Value: 400})
+	mb.Push(testMessage{ID: 5, Value: 500}) // This one drops
+
+	// Pop - should report 1 dropped (not 3)
+	result = mb.Pop()
+	if result == nil {
+		t.Fatal("expected message")
+	}
+	if result.Message.ID != 4 {
+		t.Errorf("expected ID 4, got %d", result.Message.ID)
+	}
+	if result.DroppedSinceLastRead != 1 {
+		t.Errorf("expected 1 dropped, got %d", result.DroppedSinceLastRead)
+	}
+}
+
+func TestMailbox_RingBufferWrapAround(t *testing.T) {
+	mb := NewMailbox[testMessage](3)
+
+	// Fill the buffer
+	mb.Push(testMessage{ID: 1, Value: 100})
+	mb.Push(testMessage{ID: 2, Value: 200})
+	mb.Push(testMessage{ID: 3, Value: 300})
+
+	// Pop two messages
+	mb.Pop()
+	mb.Pop()
+
+	// Add two more (should wrap around)
+	mb.Push(testMessage{ID: 4, Value: 400})
+	mb.Push(testMessage{ID: 5, Value: 500})
+
+	// Pop remaining in order
+	result := mb.Pop()
+	if result.Message.ID != 3 {
+		t.Errorf("expected ID 3, got %d", result.Message.ID)
+	}
+
+	result = mb.Pop()
+	if result.Message.ID != 4 {
+		t.Errorf("expected ID 4, got %d", result.Message.ID)
+	}
+
+	result = mb.Pop()
+	if result.Message.ID != 5 {
+		t.Errorf("expected ID 5, got %d", result.Message.ID)
+	}
+
+	// Should be empty
+	result = mb.Pop()
+	if result != nil {
+		t.Error("expected nil after draining")
+	}
+}
+
+func TestMailbox_SingleCapacity(t *testing.T) {
+	mb := NewMailbox[testMessage](1)
+
+	mb.Push(testMessage{ID: 1, Value: 100})
+	mb.Push(testMessage{ID: 2, Value: 200}) // Dropped
+
+	result := mb.Pop()
+	if result == nil {
+		t.Fatal("expected message")
+	}
+	if result.Message.ID != 1 {
+		t.Errorf("expected ID 1, got %d", result.Message.ID)
+	}
+	if result.DroppedSinceLastRead != 1 {
+		t.Errorf("expected 1 dropped, got %d", result.DroppedSinceLastRead)
+	}
+
+	result = mb.Pop()
+	if result != nil {
+		t.Error("expected nil after draining single-capacity mailbox")
+	}
+}
+
+func TestMutexMailbox_Basic(t *testing.T) {
+	mb := NewMutexMailbox[testMessage](4)
+
+	mb.Push(testMessage{ID: 1, Value: 100})
+	mb.Push(testMessage{ID: 2, Value: 200})
+
+	if mb.Len() != 2 {
+		t.Errorf("expected len 2, got %d", mb.Len())
+	}
+	if mb.IsEmpty() {
+		t.Error("expected not empty")
+	}
+
+	result := mb.Pop()
+	if result == nil || result.Message.ID != 1 {
+		t.Error("expected first message with ID 1")
+	}
+
+	result = mb.Pop()
+	if result == nil || result.Message.ID != 2 {
+		t.Error("expected second message with ID 2")
+	}
+
+	if !mb.IsEmpty() {
+		t.Error("expected empty after draining")
+	}
+	if mb.Pop() != nil {
+		t.Error("expected nil from empty mailbox")
+	}
+}
+
+func TestMutexMailbox_Overflow(t *testing.T) {
+	mb := NewMutexMailbox[testMessage](2)
+
+	mb.Push(testMessage{ID: 1, Value: 100})
+	mb.Push(testMessage{ID: 2, Value: 200})
+	mb.Push(testMessage{ID: 3, Value: 300}) // Dropped
+	mb.Push(testMessage{ID: 4, Value: 400}) // Dropped
+
+	result := mb.Pop()
+	if result == nil {
+		t.Fatal("expected message")
+	}
+	if result.Message.ID != 1 {
+		t.Errorf("expected ID 1, got %d", result.Message.ID)
+	}
+	if result.DroppedSinceLastRead != 2 {
+		t.Errorf("expected 2 dropped, got %d", result.DroppedSinceLastRead)
+	}
+
+	result = mb.Pop()
+	if result == nil || result.Message.ID != 2 {
+		t.Error("expected second message with ID 2")
+	}
+	if result.DroppedSinceLastRead != 0 {
+		t.Errorf("expected 0 dropped after reset, got %d", result.DroppedSinceLastRead)
+	}
+}
+
+func TestMutexMailbox_ConcurrentProducers(t *testing.T) {
+	mb := NewMutexMailbox[int](1000)
+	const messagesPerThread = 100
+	const numThreads = 4
+
+	var wg sync.WaitGroup
+	for i := 0; i < numThreads; i++ {
+		wg.Add(1)
+		go func(base int) {
+			defer wg.Done()
+			for j := 0; j < messagesPerThread; j++ {
+				mb.Push(base + j)
+			}
+		}(i * messagesPerThread)
+	}
+	wg.Wait()
+
+	// Should have all messages (capacity 1000 > 400 total)
+	if mb.Len() != numThreads*messagesPerThread {
+		t.Errorf("expected %d messages, got %d", numThreads*messagesPerThread, mb.Len())
+	}
+
+	// Drain and count
+	count := 0
+	for mb.Pop() != nil {
+		count++
+	}
+	if count != numThreads*messagesPerThread {
+		t.Errorf("expected to drain %d messages, got %d", numThreads*messagesPerThread, count)
+	}
+}
+
+func BenchmarkMailbox_PushPop(b *testing.B) {
+	mb := NewMailbox[testMessage](1000)
+	msg := testMessage{ID: 1, Value: 100}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mb.Push(msg)
+		mb.Pop()
+	}
+}
+
+func BenchmarkMutexMailbox_PushPop(b *testing.B) {
+	mb := NewMutexMailbox[testMessage](1000)
+	msg := testMessage{ID: 1, Value: 100}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mb.Push(msg)
+		mb.Pop()
+	}
+}

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -1,0 +1,370 @@
+// cmd/analyze profiles spread deviation distribution across datasets.
+// Usage: go run ./cmd/analyze -dataset chaos -symbol BTC
+package main
+
+import (
+	"dropbear/clocky"
+	"dropbear/decimal"
+	"dropbear/ds"
+	"dropbear/indicators"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"sort"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+var (
+	flagDataset = flag.String("dataset", "chaos", "dataset name")
+	flagSymbol  = flag.String("symbol", "BTC", "coinbase product to analyze")
+	flagSize    = decimal.Flag("size", "200", "order size in usd for depth calculation")
+	flagSamples = flag.Int("samples", 7000, "number of samples for baseline ema")
+	flagBuckets = flag.Int("buckets", 20, "number of histogram buckets")
+)
+
+// Stats holds distribution statistics
+type Stats struct {
+	Count    int
+	Mean     float64
+	StdDev   float64
+	Skewness float64
+	Kurtosis float64
+	Min      float64
+	Max      float64
+	Median   float64
+	P5       float64
+	P95      float64
+}
+
+func main() {
+	flag.Parse()
+
+	home := os.Getenv("HOME")
+
+	// Determine binance symbol (no dash, e.g., BTCFDUSD)
+	binanceSymbol := *flagSymbol + "FDUSD"
+	if *flagSymbol == "ZEC" {
+		binanceSymbol = *flagSymbol + "USDT"
+	}
+
+	// Open market data files
+	coinbasePath := home + "/marketdata/" + *flagDataset + "/coinbase/" + *flagSymbol + "-USD"
+	binancePath := home + "/marketdata/" + *flagDataset + "/binance/" + binanceSymbol
+
+	coinbaseReader := openMarketData(coinbasePath)
+	binanceReader := openMarketData(binancePath)
+	defer coinbaseReader.Close()
+	defer binanceReader.Close()
+
+	// Initialize state
+	spreadEMA := indicators.NewWWMA(*flagSamples)
+	coinbaseBook := ds.NewBook()
+	var binancePrice decimal.Decimal
+	var deviations []float64
+	warmedUp := false
+
+	// Read and merge ticks by time
+	var coinbaseTick, binanceTick ds.Tick
+	coinbaseErr := coinbaseReader.Read(&coinbaseTick)
+	binanceErr := binanceReader.Read(&binanceTick)
+
+	for coinbaseErr == nil || binanceErr == nil {
+		// Process the earlier tick
+		processCoinbase := false
+		processBinance := false
+
+		if coinbaseErr != nil {
+			processBinance = true
+		} else if binanceErr != nil {
+			processCoinbase = true
+		} else if coinbaseTick.Time.Before(binanceTick.Time) {
+			processCoinbase = true
+		} else {
+			processBinance = true
+		}
+
+		if processCoinbase {
+			// Update order book
+			coinbaseBook.Lock.Lock()
+			if coinbaseTick.Snap {
+				coinbaseBook.Clear()
+			}
+			for _, bid := range coinbaseTick.Bids {
+				coinbaseBook.UpdateBid(bid.Price, bid.Size)
+			}
+			for _, ask := range coinbaseTick.Asks {
+				coinbaseBook.UpdateAsk(ask.Price, ask.Size)
+			}
+			coinbaseBook.Lock.Unlock()
+
+			// Record deviation if we have binance price
+			if binancePrice.IsPositive() {
+				dev := recordDeviation(coinbaseBook, binancePrice, spreadEMA, *flagSize, &warmedUp)
+				if dev != nil {
+					deviations = append(deviations, *dev)
+				}
+			}
+
+			coinbaseErr = coinbaseReader.Read(&coinbaseTick)
+		}
+
+		if processBinance {
+			// Update binance price from trades
+			for _, trade := range binanceTick.Trades {
+				if trade.Price.IsPositive() {
+					binancePrice = trade.Price
+				}
+			}
+
+			// Record deviation if we have order book data
+			bestBid, _ := coinbaseBook.BestBidAsk()
+			if bestBid.IsPositive() {
+				dev := recordDeviation(coinbaseBook, binancePrice, spreadEMA, *flagSize, &warmedUp)
+				if dev != nil {
+					deviations = append(deviations, *dev)
+				}
+			}
+
+			binanceErr = binanceReader.Read(&binanceTick)
+		}
+	}
+
+	// Print results
+	printResults(*flagSymbol, *flagDataset, deviations, *flagBuckets)
+}
+
+type marketDataReader struct {
+	file   *os.File
+	reader *zstd.Decoder
+}
+
+func openMarketData(path string) *marketDataReader {
+	file, err := os.Open(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open %s: %v\n", path, err)
+		os.Exit(1)
+	}
+	reader, err := zstd.NewReader(file)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create zstd reader: %v\n", err)
+		os.Exit(1)
+	}
+	return &marketDataReader{file: file, reader: reader}
+}
+
+func (m *marketDataReader) Read(tick *ds.Tick) error {
+	return tick.Deserialize(m.reader)
+}
+
+func (m *marketDataReader) Close() {
+	m.reader.Close()
+	m.file.Close()
+}
+
+func recordDeviation(book *ds.Book, binancePrice decimal.Decimal, ema *indicators.WWMA, size decimal.Decimal, warmedUp *bool) *float64 {
+	if binancePrice.IsZero() {
+		return nil
+	}
+
+	// Compute spread
+	depth := size.Div(binancePrice)
+	bid := book.PickBid(depth)
+	ask := book.PickAsk(depth)
+	if bid.IsZero() || ask.IsZero() {
+		return nil
+	}
+
+	coinbasePrice := bid.Add(ask).DivInt(2)
+	spread := coinbasePrice.Sub(binancePrice).Div(binancePrice)
+
+	ema.Add(spread)
+	if !ema.IsReady() {
+		return nil
+	}
+
+	if !*warmedUp {
+		*warmedUp = true
+	}
+
+	baseline := ema.Value
+	deviation := spread.Sub(baseline)
+	devBPS := deviation.BPS().Float64()
+	return &devBPS
+}
+
+func ignore(err error) {
+	if err != nil && err != io.EOF {
+		fmt.Fprintf(os.Stderr, "warning: %v\n", err)
+	}
+}
+
+// Suppress unused variable warning
+var _ = clocky.Now
+
+func printResults(symbol, dataset string, deviations []float64, buckets int) {
+	if len(deviations) == 0 {
+		fmt.Println("No deviations recorded")
+		return
+	}
+
+	stats := computeStats(deviations)
+
+	fmt.Println()
+	fmt.Printf("# Spread Deviation Analysis: %s/%s\n", dataset, symbol)
+	fmt.Printf("# Samples: %d\n", stats.Count)
+	fmt.Println()
+
+	// Summary statistics
+	fmt.Println("## Statistics (basis points)")
+	fmt.Printf("mean     = %+.4f\n", stats.Mean)
+	fmt.Printf("stddev   = %.4f\n", stats.StdDev)
+	fmt.Printf("skewness = %+.4f\n", stats.Skewness)
+	fmt.Printf("kurtosis = %.4f\n", stats.Kurtosis)
+	fmt.Printf("min      = %+.4f\n", stats.Min)
+	fmt.Printf("max      = %+.4f\n", stats.Max)
+	fmt.Printf("median   = %+.4f\n", stats.Median)
+	fmt.Printf("p5       = %+.4f\n", stats.P5)
+	fmt.Printf("p95      = %+.4f\n", stats.P95)
+	fmt.Println()
+
+	// Threshold analysis
+	fmt.Println("## Threshold Crossings")
+	thresholds := []float64{1, 2, 3, 4, 5, 7, 10}
+	for _, t := range thresholds {
+		buyCount := 0
+		sellCount := 0
+		for _, d := range deviations {
+			if d < -t {
+				buyCount++
+			}
+			if d > t {
+				sellCount++
+			}
+		}
+		buyPct := float64(buyCount) / float64(len(deviations)) * 100
+		sellPct := float64(sellCount) / float64(len(deviations)) * 100
+		fmt.Printf("threshold=%2.0fbps: buy_signals=%5.2f%% sell_signals=%5.2f%%\n", t, buyPct, sellPct)
+	}
+	fmt.Println()
+
+	// Histogram
+	fmt.Println("## Histogram")
+	printHistogram(deviations, buckets)
+}
+
+func computeStats(data []float64) Stats {
+	n := len(data)
+	if n == 0 {
+		return Stats{}
+	}
+
+	// Sort for percentiles
+	sorted := make([]float64, n)
+	copy(sorted, data)
+	sort.Float64s(sorted)
+
+	// Mean
+	sum := 0.0
+	for _, v := range data {
+		sum += v
+	}
+	mean := sum / float64(n)
+
+	// Variance, skewness, kurtosis
+	variance := 0.0
+	skewSum := 0.0
+	kurtSum := 0.0
+	for _, v := range data {
+		diff := v - mean
+		variance += diff * diff
+		skewSum += diff * diff * diff
+		kurtSum += diff * diff * diff * diff
+	}
+	variance /= float64(n)
+	stddev := math.Sqrt(variance)
+
+	skewness := 0.0
+	kurtosis := 0.0
+	if stddev > 0 {
+		skewness = (skewSum / float64(n)) / (stddev * stddev * stddev)
+		kurtosis = (kurtSum / float64(n)) / (variance * variance)
+	}
+
+	return Stats{
+		Count:    n,
+		Mean:     mean,
+		StdDev:   stddev,
+		Skewness: skewness,
+		Kurtosis: kurtosis,
+		Min:      sorted[0],
+		Max:      sorted[n-1],
+		Median:   sorted[n/2],
+		P5:       sorted[n*5/100],
+		P95:      sorted[n*95/100],
+	}
+}
+
+func printHistogram(data []float64, buckets int) {
+	if len(data) == 0 {
+		return
+	}
+
+	// Find range
+	minVal := data[0]
+	maxVal := data[0]
+	for _, v := range data {
+		if v < minVal {
+			minVal = v
+		}
+		if v > maxVal {
+			maxVal = v
+		}
+	}
+
+	// Symmetric range around 0
+	absMax := math.Max(math.Abs(minVal), math.Abs(maxVal))
+	minVal = -absMax
+	maxVal = absMax
+
+	bucketSize := (maxVal - minVal) / float64(buckets)
+	counts := make([]int, buckets)
+
+	for _, v := range data {
+		idx := int((v - minVal) / bucketSize)
+		if idx >= buckets {
+			idx = buckets - 1
+		}
+		if idx < 0 {
+			idx = 0
+		}
+		counts[idx]++
+	}
+
+	// Find max count for scaling
+	maxCount := 0
+	for _, c := range counts {
+		if c > maxCount {
+			maxCount = c
+		}
+	}
+
+	// Print histogram
+	barWidth := 50
+	for i := 0; i < buckets; i++ {
+		low := minVal + float64(i)*bucketSize
+		high := low + bucketSize
+		pct := float64(counts[i]) / float64(len(data)) * 100
+		barLen := 0
+		if maxCount > 0 {
+			barLen = counts[i] * barWidth / maxCount
+		}
+		bar := ""
+		for j := 0; j < barLen; j++ {
+			bar += "█"
+		}
+		fmt.Printf("%+6.2f to %+6.2f | %5.2f%% %s\n", low, high, pct, bar)
+	}
+}

--- a/cmd/buygap/main.go
+++ b/cmd/buygap/main.go
@@ -1,0 +1,438 @@
+// cmd/buygap analyzes buy gap protection and decay function effectiveness.
+// Usage: go run ./cmd/buygap -dataset chaos -symbol BTC
+package main
+
+import (
+	"dropbear/clocky"
+	"dropbear/decimal"
+	"dropbear/ds"
+	"dropbear/indicators"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+var (
+	flagDataset  = flag.String("dataset", "chaos", "dataset name")
+	flagSymbol   = flag.String("symbol", "BTC", "coinbase product to analyze")
+	flagSamples  = flag.Int("samples", 7000, "number of samples for baseline ema")
+	flagSpread   = decimal.Flag("spread", "2", "spread threshold in basis points")
+	flagTarget   = decimal.Flag("target", "5000", "target inventory in USD")
+	flagBuyGap   = decimal.FlagBPS("buygap", "5", "only buy if price is this many basis points below last buy")
+	flagBuyDecay = clocky.DurationFlag("decay", "30s", "base decay period for buygap after sells")
+)
+
+// BuyEvent represents a potential buy with gap protection logic
+type BuyEvent struct {
+	Time           clocky.Time
+	Price          decimal.Decimal
+	Deviation      decimal.Decimal
+	TopCost        decimal.Decimal
+	InventoryValue decimal.Decimal
+	InventoryScale decimal.Decimal
+	DecayFactor    decimal.Decimal
+	EffectiveGap   decimal.Decimal
+	ActualGap      decimal.Decimal
+	Blocked        bool
+	TimeSinceSell  clocky.Duration
+}
+
+func main() {
+	flag.Parse()
+
+	home := os.Getenv("HOME")
+
+	// Determine binance symbol
+	binanceSymbol := *flagSymbol + "FDUSD"
+	if *flagSymbol == "ZEC" {
+		binanceSymbol = *flagSymbol + "USDT"
+	}
+
+	// Open market data files
+	coinbasePath := home + "/marketdata/" + *flagDataset + "/coinbase/" + *flagSymbol + "-USD"
+	binancePath := home + "/marketdata/" + *flagDataset + "/binance/" + binanceSymbol
+
+	coinbaseReader := openMarketData(coinbasePath)
+	binanceReader := openMarketData(binancePath)
+	defer coinbaseReader.Close()
+	defer binanceReader.Close()
+
+	// Initialize indicators
+	spreadEMA := indicators.NewWWMA(*flagSamples)
+
+	// Initialize state
+	coinbaseBook := ds.NewBook()
+	var binancePrice decimal.Decimal
+	var coinbasePrice decimal.Decimal
+	warmedUp := false
+
+	// Simulation state (tracking inventory like the real bot)
+	inventoryQty := decimal.Zero
+	var topCost decimal.Decimal
+	var lastSellTime clocky.Time
+
+	// Track buy events
+	var buyEvents []BuyEvent
+
+	// Read and merge ticks by time
+	var coinbaseTick, binanceTick ds.Tick
+	coinbaseErr := coinbaseReader.Read(&coinbaseTick)
+	binanceErr := binanceReader.Read(&binanceTick)
+
+	spreadThreshold := (*flagSpread).Div(decimal.Parse("10000"))
+
+	for coinbaseErr == nil || binanceErr == nil {
+		processCoinbase := false
+		processBinance := false
+
+		if coinbaseErr != nil {
+			processBinance = true
+		} else if binanceErr != nil {
+			processCoinbase = true
+		} else if coinbaseTick.Time.Before(binanceTick.Time) {
+			processCoinbase = true
+		} else {
+			processBinance = true
+		}
+
+		if processCoinbase {
+			now := coinbaseTick.Time
+
+			// Update order book
+			coinbaseBook.Lock.Lock()
+			if coinbaseTick.Snap {
+				coinbaseBook.Clear()
+			}
+			for _, bid := range coinbaseTick.Bids {
+				coinbaseBook.UpdateBid(bid.Price, bid.Size)
+			}
+			for _, ask := range coinbaseTick.Asks {
+				coinbaseBook.UpdateAsk(ask.Price, ask.Size)
+			}
+			coinbaseBook.Lock.Unlock()
+
+			// Update price from trades
+			for _, trade := range coinbaseTick.Trades {
+				if trade.Price.IsPositive() {
+					coinbasePrice = trade.Price
+				}
+			}
+
+			// Check for buy signals
+			if binancePrice.IsPositive() && coinbasePrice.IsPositive() {
+				spread := coinbasePrice.Sub(binancePrice).Div(binancePrice)
+				spreadEMA.Add(spread)
+
+				if spreadEMA.IsReady() {
+					if !warmedUp {
+						warmedUp = true
+					}
+
+					baseline := spreadEMA.Value
+					deviation := spread.Sub(baseline)
+
+					// Check for buy signal (negative deviation = coinbase cheaper than expected)
+					if deviation.Neg().Cmp(spreadThreshold) > 0 {
+						// This is a buy signal - analyze gap protection
+						buyPrice := coinbasePrice
+						inventoryValue := inventoryQty.Mul(buyPrice)
+
+						// Calculate inventory scale
+						inventoryScale := decimal.One
+						if (*flagTarget).IsPositive() {
+							invRatio := inventoryValue.Div(*flagTarget)
+							inventoryScale = decimal.One.Add(invRatio) // 1 + inv/target
+						}
+
+						// Calculate decay factor
+						decayFactor := decimal.One
+						timeSinceSell := clocky.Duration(0)
+						if (*flagTarget).IsPositive() && !lastSellTime.IsZero() {
+							invRatio := inventoryValue.Div(*flagTarget)
+							timeSinceSell = now.Sub(lastSellTime)
+							if timeSinceSell > 0 {
+								timeRatio := decimal.FromInt(int(timeSinceSell)).Div(decimal.FromInt(int(*flagBuyDecay)))
+								periodScale := invRatio.MulInt(2).Neg().Exp()                // e^(-invRatio*2)
+								decayFactor = timeRatio.Mul(periodScale).Neg().Exp()         // e^(-timeRatio*periodScale)
+								decayFactor = decayFactor.Max(decimal.Zero).Min(decimal.One) // clamp [0,1]
+							}
+						}
+
+						// Effective buygap
+						effectiveBuygap := (*flagBuyGap).Mul(inventoryScale).Mul(decayFactor)
+
+						// Check if blocked by gap
+						blocked := false
+						actualGap := decimal.Zero
+						if !topCost.IsZero() && effectiveBuygap.BPS().Cmp(decimal.Tenth) > 0 {
+							maxBuyPrice := topCost.Mul(decimal.One.Sub(effectiveBuygap))
+							actualGap = topCost.Sub(buyPrice).Div(topCost)
+							if buyPrice.Cmp(maxBuyPrice) > 0 {
+								blocked = true
+							}
+						}
+
+						buyEvents = append(buyEvents, BuyEvent{
+							Time:           now,
+							Price:          buyPrice,
+							Deviation:      deviation,
+							TopCost:        topCost,
+							InventoryValue: inventoryValue,
+							InventoryScale: inventoryScale,
+							DecayFactor:    decayFactor,
+							EffectiveGap:   effectiveBuygap,
+							ActualGap:      actualGap,
+							Blocked:        blocked,
+							TimeSinceSell:  timeSinceSell,
+						})
+
+						// Execute buy if not blocked
+						if !blocked {
+							buyQty := decimal.FromInt(100).Div(buyPrice) // $100 per buy
+							inventoryQty = inventoryQty.Add(buyQty)
+							topCost = buyPrice // Update top of stack
+						}
+					} else if deviation.Cmp(spreadThreshold) > 0 && inventoryQty.IsPositive() {
+						// Sell signal - execute if we have inventory
+						sellQty := decimal.FromInt(100).Div(coinbasePrice)
+						if sellQty.Cmp(inventoryQty) > 0 {
+							sellQty = inventoryQty
+						}
+						inventoryQty = inventoryQty.Sub(sellQty)
+						lastSellTime = now
+
+						// If sold everything, reset top cost
+						if inventoryQty.IsZero() {
+							topCost = decimal.Zero
+						}
+					}
+				}
+			}
+
+			coinbaseErr = coinbaseReader.Read(&coinbaseTick)
+		}
+
+		if processBinance {
+			for _, trade := range binanceTick.Trades {
+				if trade.Price.IsPositive() {
+					binancePrice = trade.Price
+				}
+			}
+			binanceErr = binanceReader.Read(&binanceTick)
+		}
+	}
+
+	// Print results
+	printResults(*flagSymbol, *flagDataset, buyEvents, *flagBuyGap, *flagBuyDecay)
+}
+
+type marketDataReader struct {
+	file   *os.File
+	reader *zstd.Decoder
+}
+
+func openMarketData(path string) *marketDataReader {
+	file, err := os.Open(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open %s: %v\n", path, err)
+		os.Exit(1)
+	}
+	reader, err := zstd.NewReader(file)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create zstd reader: %v\n", err)
+		os.Exit(1)
+	}
+	return &marketDataReader{file: file, reader: reader}
+}
+
+func (m *marketDataReader) Read(tick *ds.Tick) error {
+	return tick.Deserialize(m.reader)
+}
+
+func (m *marketDataReader) Close() {
+	m.reader.Close()
+	m.file.Close()
+}
+
+func printResults(symbol, dataset string, events []BuyEvent, buygap decimal.Decimal, decay clocky.Duration) {
+	fmt.Println()
+	fmt.Printf("# Buy Gap Analysis: %s/%s (gap=%sbps decay=%s)\n",
+		dataset, symbol, buygap.BPS().Format(1), decay)
+	fmt.Println()
+
+	totalSignals := len(events)
+	if totalSignals == 0 {
+		fmt.Println("No buy signals found")
+		return
+	}
+
+	// Count blocked vs executed
+	blocked := 0
+	executed := 0
+	for _, e := range events {
+		if e.Blocked {
+			blocked++
+		} else {
+			executed++
+		}
+	}
+
+	fmt.Println("## Signal Overview")
+	fmt.Printf("Total Buy Signals:  %d\n", totalSignals)
+	fmt.Printf("Executed:           %d (%.1f%%)\n", executed, float64(executed)/float64(totalSignals)*100)
+	fmt.Printf("Blocked by Gap:     %d (%.1f%%)\n", blocked, float64(blocked)/float64(totalSignals)*100)
+	fmt.Println()
+
+	// Analyze gap distribution for blocked signals
+	if blocked > 0 {
+		fmt.Println("## Blocked Signals Analysis")
+		var blockedGaps []float64
+		var blockedEffectiveGaps []float64
+		for _, e := range events {
+			if e.Blocked {
+				blockedGaps = append(blockedGaps, e.ActualGap.BPS().Float64())
+				blockedEffectiveGaps = append(blockedEffectiveGaps, e.EffectiveGap.BPS().Float64())
+			}
+		}
+
+		sort.Float64s(blockedGaps)
+		sort.Float64s(blockedEffectiveGaps)
+
+		fmt.Println("### Actual Gap (how far below last buy)")
+		printDistribution(blockedGaps, "bps")
+
+		fmt.Println()
+		fmt.Println("### Effective Gap Threshold")
+		printDistribution(blockedEffectiveGaps, "bps")
+		fmt.Println()
+	}
+
+	// Analyze decay factor distribution
+	var decayFactors []float64
+	var inventoryScales []float64
+	for _, e := range events {
+		if !e.DecayFactor.IsZero() {
+			decayFactors = append(decayFactors, e.DecayFactor.Float64())
+		}
+		if !e.InventoryScale.IsZero() && e.InventoryScale.Cmp(decimal.One) != 0 {
+			inventoryScales = append(inventoryScales, e.InventoryScale.Float64())
+		}
+	}
+
+	if len(decayFactors) > 0 {
+		fmt.Println("## Decay Factor Distribution")
+		sort.Float64s(decayFactors)
+		printDistribution(decayFactors, "")
+		fmt.Println()
+	}
+
+	if len(inventoryScales) > 0 {
+		fmt.Println("## Inventory Scale Distribution")
+		sort.Float64s(inventoryScales)
+		printDistribution(inventoryScales, "x")
+		fmt.Println()
+	}
+
+	// Time since sell analysis
+	var timeSinceSells []float64
+	for _, e := range events {
+		if e.TimeSinceSell > 0 {
+			timeSinceSells = append(timeSinceSells, float64(e.TimeSinceSell))
+		}
+	}
+
+	if len(timeSinceSells) > 0 {
+		fmt.Println("## Time Since Last Sell")
+		sort.Float64s(timeSinceSells)
+		// Convert to seconds for display
+		n := len(timeSinceSells)
+		fmt.Printf("Samples: %d\n", n)
+		fmt.Printf("Min:     %.1fs\n", timeSinceSells[0]/1e9)
+		fmt.Printf("P50:     %.1fs\n", timeSinceSells[n/2]/1e9)
+		fmt.Printf("P95:     %.1fs\n", timeSinceSells[n*95/100]/1e9)
+		fmt.Printf("Max:     %.1fs\n", timeSinceSells[n-1]/1e9)
+		fmt.Println()
+	}
+
+	// Gap effectiveness zones
+	fmt.Println("## Gap Protection Effectiveness")
+	type zoneStats struct {
+		total   int
+		blocked int
+	}
+	zones := map[string]*zoneStats{
+		"early": {}, // inventory < 25% target
+		"mid":   {}, // 25-75%
+		"late":  {}, // 75-100%
+		"over":  {}, // > 100%
+	}
+
+	for _, e := range events {
+		var zone string
+		invPct := e.InventoryValue.Div(decimal.Parse("5000")).Float64() * 100
+		switch {
+		case invPct < 25:
+			zone = "early"
+		case invPct < 75:
+			zone = "mid"
+		case invPct < 100:
+			zone = "late"
+		default:
+			zone = "over"
+		}
+
+		z := zones[zone]
+		z.total++
+		if e.Blocked {
+			z.blocked++
+		}
+	}
+
+	fmt.Printf("%-12s  %8s  %8s  %10s\n", "Inv Zone", "Signals", "Blocked", "Block Rate")
+	for _, name := range []string{"early", "mid", "late", "over"} {
+		z := zones[name]
+		if z.total > 0 {
+			blockRate := float64(z.blocked) / float64(z.total) * 100
+			label := map[string]string{
+				"early": "Early (<25%)",
+				"mid":   "Mid (25-75%)",
+				"late":  "Late (75-100%)",
+				"over":  "Over (>100%)",
+			}[name]
+			fmt.Printf("%-12s  %8d  %8d  %9.1f%%\n", label, z.total, z.blocked, blockRate)
+		}
+	}
+}
+
+func printDistribution(values []float64, unit string) {
+	if len(values) == 0 {
+		return
+	}
+
+	n := len(values)
+	sum := 0.0
+	for _, v := range values {
+		sum += v
+	}
+	mean := sum / float64(n)
+
+	variance := 0.0
+	for _, v := range values {
+		diff := v - mean
+		variance += diff * diff
+	}
+	stddev := math.Sqrt(variance / float64(n))
+
+	fmt.Printf("Samples: %d\n", n)
+	fmt.Printf("Mean:    %.2f%s\n", mean, unit)
+	fmt.Printf("StdDev:  %.2f%s\n", stddev, unit)
+	fmt.Printf("Min:     %.2f%s\n", values[0], unit)
+	fmt.Printf("P5:      %.2f%s\n", values[n*5/100], unit)
+	fmt.Printf("P50:     %.2f%s\n", values[n/2], unit)
+	fmt.Printf("P95:     %.2f%s\n", values[n*95/100], unit)
+	fmt.Printf("Max:     %.2f%s\n", values[n-1], unit)
+}

--- a/cmd/disposition/main.go
+++ b/cmd/disposition/main.go
@@ -15,12 +15,12 @@ import (
 )
 
 var (
-	flagDataset = flag.String("dataset", "chaos", "dataset name")
-	flagSymbol  = flag.String("symbol", "BTC", "coinbase product to analyze")
-	flagWindow  = clocky.DurationFlag("window", "42m", "time window for min/max range")
-	flagComfort = decimal.FlagPercent("comfort", "20", "comfort zone percentage")
-	flagSamples = flag.Int("samples", 7000, "number of samples for baseline ema")
-	flagSpread  = decimal.Flag("spread", "2", "spread threshold in basis points")
+	flagDataset   = flag.String("dataset", "chaos", "dataset name")
+	flagSymbol    = flag.String("symbol", "BTC", "coinbase product to analyze")
+	flagWindow    = clocky.DurationFlag("window", "42m", "time window for min/max range")
+	flagComfort   = decimal.FlagPercent("comfort", "20", "comfort zone percentage")
+	flagSamples   = flag.Int("samples", 7000, "number of samples for baseline ema")
+	flagSpread    = decimal.Flag("spread", "2", "spread threshold in basis points")
 	flagLookahead = clocky.DurationFlag("lookahead", "5m", "time to look ahead for outcome")
 )
 

--- a/cmd/disposition/main.go
+++ b/cmd/disposition/main.go
@@ -1,0 +1,411 @@
+// cmd/disposition analyzes effectiveness of the price-range disposition filter.
+// Usage: go run ./cmd/disposition -dataset chaos -symbol BTC
+package main
+
+import (
+	"dropbear/clocky"
+	"dropbear/decimal"
+	"dropbear/ds"
+	"dropbear/indicators"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+var (
+	flagDataset = flag.String("dataset", "chaos", "dataset name")
+	flagSymbol  = flag.String("symbol", "BTC", "coinbase product to analyze")
+	flagWindow  = clocky.DurationFlag("window", "42m", "time window for min/max range")
+	flagComfort = decimal.FlagPercent("comfort", "20", "comfort zone percentage")
+	flagSamples = flag.Int("samples", 7000, "number of samples for baseline ema")
+	flagSpread  = decimal.Flag("spread", "2", "spread threshold in basis points")
+	flagLookahead = clocky.DurationFlag("lookahead", "5m", "time to look ahead for outcome")
+)
+
+// Disposition represents price position in recent range
+type Disposition int
+
+const (
+	TooCheap Disposition = iota
+	Cheap
+	Normal
+	Expensive
+	TooExpensive
+)
+
+func (d Disposition) String() string {
+	return [...]string{"TooCheap", "Cheap", "Normal", "Expensive", "TooExpensive"}[d]
+}
+
+// Signal represents a trading signal
+type Signal struct {
+	Time        clocky.Time
+	Disposition Disposition
+	Deviation   decimal.Decimal
+	Side        ds.Side // SideBuy or SideSell
+	Price       decimal.Decimal
+}
+
+// Outcome tracks what happened after a signal
+type Outcome struct {
+	Signal      Signal
+	FuturePrice decimal.Decimal
+	ProfitBPS   float64
+}
+
+func main() {
+	flag.Parse()
+
+	home := os.Getenv("HOME")
+
+	// Determine binance symbol (no dash, e.g., BTCFDUSD)
+	binanceSymbol := *flagSymbol + "FDUSD"
+	if *flagSymbol == "ZEC" {
+		binanceSymbol = *flagSymbol + "USDT"
+	}
+
+	// Open market data files
+	coinbasePath := home + "/marketdata/" + *flagDataset + "/coinbase/" + *flagSymbol + "-USD"
+	binancePath := home + "/marketdata/" + *flagDataset + "/binance/" + binanceSymbol
+
+	coinbaseReader := openMarketData(coinbasePath)
+	binanceReader := openMarketData(binancePath)
+	defer coinbaseReader.Close()
+	defer binanceReader.Close()
+
+	// Initialize indicators
+	spreadEMA := indicators.NewWWMA(*flagSamples)
+	priceMin := indicators.NewMin(*flagWindow)
+	priceMax := indicators.NewMax(*flagWindow)
+
+	// Initialize state
+	coinbaseBook := ds.NewBook()
+	var binancePrice decimal.Decimal
+	var coinbasePrice decimal.Decimal
+	warmedUp := false
+
+	// Track disposition distribution and signals
+	dispCounts := make(map[Disposition]int)
+	var signals []Signal
+	type pricePoint struct {
+		time  clocky.Time
+		price decimal.Decimal
+	}
+	var priceHistory []pricePoint // for lookahead
+
+	// Read and merge ticks by time
+	var coinbaseTick, binanceTick ds.Tick
+	coinbaseErr := coinbaseReader.Read(&coinbaseTick)
+	binanceErr := binanceReader.Read(&binanceTick)
+
+	spreadThreshold := (*flagSpread).Div(decimal.Parse("10000")) // convert bps to decimal
+
+	for coinbaseErr == nil || binanceErr == nil {
+		// Process the earlier tick
+		processCoinbase := false
+		processBinance := false
+
+		if coinbaseErr != nil {
+			processBinance = true
+		} else if binanceErr != nil {
+			processCoinbase = true
+		} else if coinbaseTick.Time.Before(binanceTick.Time) {
+			processCoinbase = true
+		} else {
+			processBinance = true
+		}
+
+		if processCoinbase {
+			now := coinbaseTick.Time
+
+			// Update order book
+			coinbaseBook.Lock.Lock()
+			if coinbaseTick.Snap {
+				coinbaseBook.Clear()
+			}
+			for _, bid := range coinbaseTick.Bids {
+				coinbaseBook.UpdateBid(bid.Price, bid.Size)
+			}
+			for _, ask := range coinbaseTick.Asks {
+				coinbaseBook.UpdateAsk(ask.Price, ask.Size)
+			}
+			coinbaseBook.Lock.Unlock()
+
+			// Update price from trades
+			for _, trade := range coinbaseTick.Trades {
+				if trade.Price.IsPositive() {
+					coinbasePrice = trade.Price
+					priceMin.Add(now, coinbasePrice)
+					priceMax.Add(now, coinbasePrice)
+					priceHistory = append(priceHistory, pricePoint{now, coinbasePrice})
+				}
+			}
+
+			// Record signal if conditions met
+			if binancePrice.IsPositive() && coinbasePrice.IsPositive() && priceMin.IsReady() {
+				// Compute spread and deviation
+				spread := coinbasePrice.Sub(binancePrice).Div(binancePrice)
+				spreadEMA.Add(spread)
+
+				if spreadEMA.IsReady() {
+					if !warmedUp {
+						warmedUp = true
+					}
+
+					baseline := spreadEMA.Value
+					deviation := spread.Sub(baseline)
+
+					// Compute disposition
+					minPrice := priceMin.Value
+					maxPrice := priceMax.Value
+					disposition := computeDisposition(coinbasePrice, minPrice, maxPrice, *flagComfort)
+					dispCounts[disposition]++
+
+					// Check for signals (ignoring disposition filter to compare)
+					if deviation.Neg().Cmp(spreadThreshold) > 0 {
+						// Buy signal
+						signals = append(signals, Signal{
+							Time:        now,
+							Disposition: disposition,
+							Deviation:   deviation,
+							Side:        ds.SideBuy,
+							Price:       coinbasePrice,
+						})
+					} else if deviation.Cmp(spreadThreshold) > 0 {
+						// Sell signal
+						signals = append(signals, Signal{
+							Time:        now,
+							Disposition: disposition,
+							Deviation:   deviation,
+							Side:        ds.SideSell,
+							Price:       coinbasePrice,
+						})
+					}
+				}
+			}
+
+			coinbaseErr = coinbaseReader.Read(&coinbaseTick)
+		}
+
+		if processBinance {
+			// Update binance price from trades
+			for _, trade := range binanceTick.Trades {
+				if trade.Price.IsPositive() {
+					binancePrice = trade.Price
+				}
+			}
+
+			binanceErr = binanceReader.Read(&binanceTick)
+		}
+	}
+
+	// Compute outcomes for signals using binary search
+	var outcomes []Outcome
+	for _, sig := range signals {
+		futureTime := sig.Time.Add(*flagLookahead)
+		// Binary search for first price at or after futureTime
+		lo, hi := 0, len(priceHistory)
+		for lo < hi {
+			mid := (lo + hi) / 2
+			if priceHistory[mid].time.Before(futureTime) {
+				lo = mid + 1
+			} else {
+				hi = mid
+			}
+		}
+		if lo < len(priceHistory) {
+			futurePrice := priceHistory[lo].price
+			var profitBPS float64
+			if sig.Side == ds.SideBuy {
+				profitBPS = futurePrice.Sub(sig.Price).Div(sig.Price).BPS().Float64()
+			} else {
+				profitBPS = sig.Price.Sub(futurePrice).Div(sig.Price).BPS().Float64()
+			}
+			outcomes = append(outcomes, Outcome{
+				Signal:      sig,
+				FuturePrice: futurePrice,
+				ProfitBPS:   profitBPS,
+			})
+		}
+	}
+
+	// Print results
+	printResults(*flagSymbol, *flagDataset, dispCounts, signals, outcomes)
+}
+
+func computeDisposition(price, minPrice, maxPrice decimal.Decimal, comfort decimal.Decimal) Disposition {
+	rangeSize := maxPrice.Sub(minPrice)
+	if !rangeSize.IsPositive() {
+		return Normal
+	}
+	rangePosition := price.Sub(minPrice).Div(rangeSize)
+
+	if rangePosition.Cmp(comfort) < 0 {
+		return Cheap
+	}
+	if rangePosition.Cmp(decimal.One.Sub(comfort)) > 0 {
+		return Expensive
+	}
+	return Normal
+}
+
+type marketDataReader struct {
+	file   *os.File
+	reader *zstd.Decoder
+}
+
+func openMarketData(path string) *marketDataReader {
+	file, err := os.Open(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open %s: %v\n", path, err)
+		os.Exit(1)
+	}
+	reader, err := zstd.NewReader(file)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create zstd reader: %v\n", err)
+		os.Exit(1)
+	}
+	return &marketDataReader{file: file, reader: reader}
+}
+
+func (m *marketDataReader) Read(tick *ds.Tick) error {
+	return tick.Deserialize(m.reader)
+}
+
+func (m *marketDataReader) Close() {
+	m.reader.Close()
+	m.file.Close()
+}
+
+func printResults(symbol, dataset string, dispCounts map[Disposition]int, signals []Signal, outcomes []Outcome) {
+	fmt.Println()
+	fmt.Printf("# Disposition Effectiveness Analysis: %s/%s\n", dataset, symbol)
+	fmt.Println()
+
+	// Disposition distribution
+	fmt.Println("## Disposition Distribution")
+	total := 0
+	for _, c := range dispCounts {
+		total += c
+	}
+	for d := TooCheap; d <= TooExpensive; d++ {
+		count := dispCounts[d]
+		pct := float64(count) / float64(total) * 100
+		fmt.Printf("%-12s: %6.2f%% (%d samples)\n", d, pct, count)
+	}
+	fmt.Println()
+
+	// Signal distribution by disposition
+	fmt.Println("## Signals by Disposition")
+	buyByDisp := make(map[Disposition]int)
+	sellByDisp := make(map[Disposition]int)
+	for _, sig := range signals {
+		if sig.Side == ds.SideBuy {
+			buyByDisp[sig.Disposition]++
+		} else {
+			sellByDisp[sig.Disposition]++
+		}
+	}
+	fmt.Printf("%-12s  %8s  %8s\n", "Disposition", "Buy", "Sell")
+	for d := TooCheap; d <= TooExpensive; d++ {
+		fmt.Printf("%-12s  %8d  %8d\n", d, buyByDisp[d], sellByDisp[d])
+	}
+	fmt.Println()
+
+	// Outcome analysis by disposition
+	fmt.Println("## Outcome by Disposition (profit in bps)")
+	type stats struct {
+		count      int
+		sumProfit  float64
+		profitable int
+	}
+	buyStats := make(map[Disposition]*stats)
+	sellStats := make(map[Disposition]*stats)
+	for d := TooCheap; d <= TooExpensive; d++ {
+		buyStats[d] = &stats{}
+		sellStats[d] = &stats{}
+	}
+
+	for _, o := range outcomes {
+		var s *stats
+		if o.Signal.Side == ds.SideBuy {
+			s = buyStats[o.Signal.Disposition]
+		} else {
+			s = sellStats[o.Signal.Disposition]
+		}
+		s.count++
+		s.sumProfit += o.ProfitBPS
+		if o.ProfitBPS > 0 {
+			s.profitable++
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("### Buy Signals")
+	fmt.Printf("%-12s  %6s  %10s  %8s\n", "Disposition", "Count", "Avg Profit", "Win Rate")
+	for d := TooCheap; d <= TooExpensive; d++ {
+		s := buyStats[d]
+		if s.count > 0 {
+			avgProfit := s.sumProfit / float64(s.count)
+			winRate := float64(s.profitable) / float64(s.count) * 100
+			fmt.Printf("%-12s  %6d  %+10.2f  %7.1f%%\n", d, s.count, avgProfit, winRate)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("### Sell Signals")
+	fmt.Printf("%-12s  %6s  %10s  %8s\n", "Disposition", "Count", "Avg Profit", "Win Rate")
+	for d := TooCheap; d <= TooExpensive; d++ {
+		s := sellStats[d]
+		if s.count > 0 {
+			avgProfit := s.sumProfit / float64(s.count)
+			winRate := float64(s.profitable) / float64(s.count) * 100
+			fmt.Printf("%-12s  %6d  %+10.2f  %7.1f%%\n", d, s.count, avgProfit, winRate)
+		}
+	}
+
+	// Summary comparison
+	fmt.Println()
+	fmt.Println("## Filter Effectiveness")
+	filteredBuys := buyStats[Cheap]
+	allBuys := &stats{}
+	for _, s := range buyStats {
+		allBuys.count += s.count
+		allBuys.sumProfit += s.sumProfit
+		allBuys.profitable += s.profitable
+	}
+
+	filteredSells := sellStats[Expensive]
+	allSells := &stats{}
+	for _, s := range sellStats {
+		allSells.count += s.count
+		allSells.sumProfit += s.sumProfit
+		allSells.profitable += s.profitable
+	}
+
+	if allBuys.count > 0 && filteredBuys.count > 0 {
+		allBuyAvg := allBuys.sumProfit / float64(allBuys.count)
+		filtBuyAvg := filteredBuys.sumProfit / float64(filteredBuys.count)
+		allBuyWin := float64(allBuys.profitable) / float64(allBuys.count) * 100
+		filtBuyWin := float64(filteredBuys.profitable) / float64(filteredBuys.count) * 100
+
+		fmt.Printf("Buys  ALL:    n=%5d avg=%+.2fbps win=%.1f%%\n", allBuys.count, allBuyAvg, allBuyWin)
+		fmt.Printf("Buys  CHEAP:  n=%5d avg=%+.2fbps win=%.1f%% (filter keeps %.1f%%)\n",
+			filteredBuys.count, filtBuyAvg, filtBuyWin,
+			float64(filteredBuys.count)/float64(allBuys.count)*100)
+	}
+
+	if allSells.count > 0 && filteredSells.count > 0 {
+		allSellAvg := allSells.sumProfit / float64(allSells.count)
+		filtSellAvg := filteredSells.sumProfit / float64(filteredSells.count)
+		allSellWin := float64(allSells.profitable) / float64(allSells.count) * 100
+		filtSellWin := float64(filteredSells.profitable) / float64(filteredSells.count) * 100
+
+		fmt.Printf("Sells ALL:    n=%5d avg=%+.2fbps win=%.1f%%\n", allSells.count, allSellAvg, allSellWin)
+		fmt.Printf("Sells EXPENSIVE: n=%5d avg=%+.2fbps win=%.1f%% (filter keeps %.1f%%)\n",
+			filteredSells.count, filtSellAvg, filtSellWin,
+			float64(filteredSells.count)/float64(allSells.count)*100)
+	}
+}

--- a/cmd/greed/main.go
+++ b/cmd/greed/main.go
@@ -1,0 +1,385 @@
+// cmd/greed analyzes the exponential greed/inventory skew parameters.
+// Usage: go run ./cmd/greed -dataset chaos -symbol BTC
+package main
+
+import (
+	"dropbear/clocky"
+	"dropbear/decimal"
+	"dropbear/ds"
+	"dropbear/indicators"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+var (
+	flagDataset = flag.String("dataset", "chaos", "dataset name")
+	flagSymbol  = flag.String("symbol", "BTC", "coinbase product to analyze")
+	flagSamples = flag.Int("samples", 7000, "number of samples for baseline ema")
+	flagSpread  = decimal.Flag("spread", "2", "spread threshold in basis points")
+	flagTarget  = decimal.Flag("target", "5000", "target inventory in USD")
+	flagSkew    = decimal.Flag("skew", "1", "exponential skew coefficient")
+)
+
+// Trade represents a simulated trade
+type Trade struct {
+	Time         clocky.Time
+	Side         ds.Side
+	Price        decimal.Decimal
+	Deviation    decimal.Decimal
+	Greed        decimal.Decimal
+	InventoryPre decimal.Decimal
+	Imbalance    decimal.Decimal
+}
+
+func main() {
+	flag.Parse()
+
+	home := os.Getenv("HOME")
+
+	// Determine binance symbol
+	binanceSymbol := *flagSymbol + "FDUSD"
+	if *flagSymbol == "ZEC" {
+		binanceSymbol = *flagSymbol + "USDT"
+	}
+
+	// Open market data files
+	coinbasePath := home + "/marketdata/" + *flagDataset + "/coinbase/" + *flagSymbol + "-USD"
+	binancePath := home + "/marketdata/" + *flagDataset + "/binance/" + binanceSymbol
+
+	coinbaseReader := openMarketData(coinbasePath)
+	binanceReader := openMarketData(binancePath)
+	defer coinbaseReader.Close()
+	defer binanceReader.Close()
+
+	// Initialize indicators
+	spreadEMA := indicators.NewWWMA(*flagSamples)
+
+	// Initialize state
+	coinbaseBook := ds.NewBook()
+	var binancePrice decimal.Decimal
+	var coinbasePrice decimal.Decimal
+	warmedUp := false
+
+	// Simulation state
+	inventoryQty := decimal.Zero    // quantity held
+	inventoryValue := decimal.Zero  // value of inventory
+	target := *flagTarget
+
+	// Track trades and metrics
+	var trades []Trade
+	var greedFactors []float64
+	var imbalances []float64
+
+	// Read and merge ticks by time
+	var coinbaseTick, binanceTick ds.Tick
+	coinbaseErr := coinbaseReader.Read(&coinbaseTick)
+	binanceErr := binanceReader.Read(&binanceTick)
+
+	spreadThreshold := (*flagSpread).Div(decimal.Parse("10000"))
+
+	for coinbaseErr == nil || binanceErr == nil {
+		processCoinbase := false
+		processBinance := false
+
+		if coinbaseErr != nil {
+			processBinance = true
+		} else if binanceErr != nil {
+			processCoinbase = true
+		} else if coinbaseTick.Time.Before(binanceTick.Time) {
+			processCoinbase = true
+		} else {
+			processBinance = true
+		}
+
+		if processCoinbase {
+			now := coinbaseTick.Time
+
+			// Update order book
+			coinbaseBook.Lock.Lock()
+			if coinbaseTick.Snap {
+				coinbaseBook.Clear()
+			}
+			for _, bid := range coinbaseTick.Bids {
+				coinbaseBook.UpdateBid(bid.Price, bid.Size)
+			}
+			for _, ask := range coinbaseTick.Asks {
+				coinbaseBook.UpdateAsk(ask.Price, ask.Size)
+			}
+			coinbaseBook.Lock.Unlock()
+
+			// Update price from trades
+			for _, trade := range coinbaseTick.Trades {
+				if trade.Price.IsPositive() {
+					coinbasePrice = trade.Price
+				}
+			}
+
+			// Check for signals
+			if binancePrice.IsPositive() && coinbasePrice.IsPositive() {
+				spread := coinbasePrice.Sub(binancePrice).Div(binancePrice)
+				spreadEMA.Add(spread)
+
+				if spreadEMA.IsReady() {
+					if !warmedUp {
+						warmedUp = true
+					}
+
+					baseline := spreadEMA.Value
+					deviation := spread.Sub(baseline)
+
+					// Calculate inventory metrics
+					inventoryValue = inventoryQty.Mul(coinbasePrice)
+					imbalance := decimal.Zero
+					greed := decimal.One
+					buySpread := spreadThreshold
+					sellSpread := spreadThreshold
+
+					if target.IsPositive() {
+						imbalance = inventoryValue.Sub(target).Div(target)
+						greed = imbalance.Mul(*flagSkew).Exp()
+						buySpread = spreadThreshold.Mul(greed)
+						sellSpread = spreadThreshold.Div(greed)
+					}
+
+					greedFactors = append(greedFactors, greed.Float64())
+					imbalances = append(imbalances, imbalance.Float64())
+
+					// Check for trade signals with greed-adjusted spreads
+					if deviation.Neg().Cmp(buySpread) > 0 {
+						// Buy signal
+						// Simulate buying $100 worth
+						buyQty := decimal.FromInt(100).Div(coinbasePrice)
+						inventoryQty = inventoryQty.Add(buyQty)
+
+						trades = append(trades, Trade{
+							Time:         now,
+							Side:         ds.SideBuy,
+							Price:        coinbasePrice,
+							Deviation:    deviation,
+							Greed:        greed,
+							InventoryPre: inventoryValue,
+							Imbalance:    imbalance,
+						})
+					} else if deviation.Cmp(sellSpread) > 0 && inventoryQty.IsPositive() {
+						// Sell signal (only if we have inventory)
+						sellQty := decimal.FromInt(100).Div(coinbasePrice)
+						if sellQty.Cmp(inventoryQty) > 0 {
+							sellQty = inventoryQty
+						}
+						inventoryQty = inventoryQty.Sub(sellQty)
+
+						trades = append(trades, Trade{
+							Time:         now,
+							Side:         ds.SideSell,
+							Price:        coinbasePrice,
+							Deviation:    deviation,
+							Greed:        greed,
+							InventoryPre: inventoryValue,
+							Imbalance:    imbalance,
+						})
+					}
+				}
+			}
+
+			coinbaseErr = coinbaseReader.Read(&coinbaseTick)
+		}
+
+		if processBinance {
+			for _, trade := range binanceTick.Trades {
+				if trade.Price.IsPositive() {
+					binancePrice = trade.Price
+				}
+			}
+			binanceErr = binanceReader.Read(&binanceTick)
+		}
+	}
+
+	// Print results
+	printResults(*flagSymbol, *flagDataset, trades, greedFactors, imbalances, *flagSkew)
+}
+
+type marketDataReader struct {
+	file   *os.File
+	reader *zstd.Decoder
+}
+
+func openMarketData(path string) *marketDataReader {
+	file, err := os.Open(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open %s: %v\n", path, err)
+		os.Exit(1)
+	}
+	reader, err := zstd.NewReader(file)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create zstd reader: %v\n", err)
+		os.Exit(1)
+	}
+	return &marketDataReader{file: file, reader: reader}
+}
+
+func (m *marketDataReader) Read(tick *ds.Tick) error {
+	return tick.Deserialize(m.reader)
+}
+
+func (m *marketDataReader) Close() {
+	m.reader.Close()
+	m.file.Close()
+}
+
+func printResults(symbol, dataset string, trades []Trade, greedFactors, imbalances []float64, skew decimal.Decimal) {
+	fmt.Println()
+	fmt.Printf("# Greed/Skew Analysis: %s/%s (skew=%.1f)\n", dataset, symbol, skew.Float64())
+	fmt.Println()
+
+	// Greed factor distribution
+	fmt.Println("## Greed Factor Distribution")
+	if len(greedFactors) > 0 {
+		sort.Float64s(greedFactors)
+		n := len(greedFactors)
+		sum := 0.0
+		for _, g := range greedFactors {
+			sum += g
+		}
+		mean := sum / float64(n)
+
+		variance := 0.0
+		for _, g := range greedFactors {
+			diff := g - mean
+			variance += diff * diff
+		}
+		stddev := math.Sqrt(variance / float64(n))
+
+		fmt.Printf("Samples: %d\n", n)
+		fmt.Printf("Mean:    %.4f\n", mean)
+		fmt.Printf("StdDev:  %.4f\n", stddev)
+		fmt.Printf("Min:     %.4f\n", greedFactors[0])
+		fmt.Printf("Max:     %.4f\n", greedFactors[n-1])
+		fmt.Printf("P5:      %.4f\n", greedFactors[n*5/100])
+		fmt.Printf("P50:     %.4f\n", greedFactors[n/2])
+		fmt.Printf("P95:     %.4f\n", greedFactors[n*95/100])
+	}
+	fmt.Println()
+
+	// Imbalance distribution
+	fmt.Println("## Imbalance Distribution")
+	if len(imbalances) > 0 {
+		sort.Float64s(imbalances)
+		n := len(imbalances)
+		sum := 0.0
+		for _, i := range imbalances {
+			sum += i
+		}
+		mean := sum / float64(n)
+
+		// Count time in each zone
+		under50 := 0 // -100% to -50%
+		under25 := 0 // -50% to -25%
+		near := 0    // -25% to +25%
+		over25 := 0  // +25% to +50%
+		over50 := 0  // +50% to +100%
+
+		for _, imb := range imbalances {
+			switch {
+			case imb < -0.5:
+				under50++
+			case imb < -0.25:
+				under25++
+			case imb < 0.25:
+				near++
+			case imb < 0.5:
+				over25++
+			default:
+				over50++
+			}
+		}
+
+		fmt.Printf("Mean Imbalance: %+.2f%%\n", mean*100)
+		fmt.Printf("Min:            %+.2f%%\n", imbalances[0]*100)
+		fmt.Printf("Max:            %+.2f%%\n", imbalances[n-1]*100)
+		fmt.Println()
+		fmt.Println("Time in Zone:")
+		fmt.Printf("  Very Underweight (<-50%%):  %5.1f%%\n", float64(under50)/float64(n)*100)
+		fmt.Printf("  Underweight (-50%% to -25%%): %5.1f%%\n", float64(under25)/float64(n)*100)
+		fmt.Printf("  Near Target (-25%% to +25%%): %5.1f%%\n", float64(near)/float64(n)*100)
+		fmt.Printf("  Overweight (+25%% to +50%%):  %5.1f%%\n", float64(over25)/float64(n)*100)
+		fmt.Printf("  Very Overweight (>+50%%):   %5.1f%%\n", float64(over50)/float64(n)*100)
+	}
+	fmt.Println()
+
+	// Trade analysis by imbalance zone
+	fmt.Println("## Trades by Imbalance Zone")
+	type zoneStats struct {
+		buys  int
+		sells int
+	}
+	zones := map[string]*zoneStats{
+		"under50": {},
+		"under25": {},
+		"near":    {},
+		"over25":  {},
+		"over50":  {},
+	}
+
+	for _, t := range trades {
+		imb := t.Imbalance.Float64()
+		var zone string
+		switch {
+		case imb < -0.5:
+			zone = "under50"
+		case imb < -0.25:
+			zone = "under25"
+		case imb < 0.25:
+			zone = "near"
+		case imb < 0.5:
+			zone = "over25"
+		default:
+			zone = "over50"
+		}
+		if t.Side == ds.SideBuy {
+			zones[zone].buys++
+		} else {
+			zones[zone].sells++
+		}
+	}
+
+	fmt.Printf("%-20s  %6s  %6s  %8s\n", "Zone", "Buys", "Sells", "Ratio")
+	for _, name := range []string{"under50", "under25", "near", "over25", "over50"} {
+		z := zones[name]
+		total := z.buys + z.sells
+		ratio := "N/A"
+		if z.sells > 0 {
+			ratio = fmt.Sprintf("%.2f", float64(z.buys)/float64(z.sells))
+		}
+		label := map[string]string{
+			"under50": "Very Underweight",
+			"under25": "Underweight",
+			"near":    "Near Target",
+			"over25":  "Overweight",
+			"over50":  "Very Overweight",
+		}[name]
+		if total > 0 {
+			fmt.Printf("%-20s  %6d  %6d  %8s\n", label, z.buys, z.sells, ratio)
+		}
+	}
+	fmt.Println()
+
+	// Summary
+	fmt.Println("## Trade Summary")
+	buyCount := 0
+	sellCount := 0
+	for _, t := range trades {
+		if t.Side == ds.SideBuy {
+			buyCount++
+		} else {
+			sellCount++
+		}
+	}
+	fmt.Printf("Total Buys:  %d\n", buyCount)
+	fmt.Printf("Total Sells: %d\n", sellCount)
+	fmt.Printf("Buy/Sell:    %.2f\n", float64(buyCount)/float64(sellCount))
+}

--- a/cmd/greed/main.go
+++ b/cmd/greed/main.go
@@ -66,8 +66,8 @@ func main() {
 	warmedUp := false
 
 	// Simulation state
-	inventoryQty := decimal.Zero    // quantity held
-	inventoryValue := decimal.Zero  // value of inventory
+	inventoryQty := decimal.Zero   // quantity held
+	inventoryValue := decimal.Zero // value of inventory
 	target := *flagTarget
 
 	// Track trades and metrics

--- a/cmd/intensity/main.go
+++ b/cmd/intensity/main.go
@@ -298,11 +298,11 @@ func printResults(symbol, dataset string, kappaValues []float64, outcomes []Outc
 
 		// Kappa zones
 		fmt.Println("Time in Zone:")
-		veryTight := 0  // > 50000
-		tight := 0      // 20000-50000
-		normal := 0     // 10000-20000
-		loose := 0      // 5000-10000
-		veryLoose := 0  // < 5000
+		veryTight := 0 // > 50000
+		tight := 0     // 20000-50000
+		normal := 0    // 10000-20000
+		loose := 0     // 5000-10000
+		veryLoose := 0 // < 5000
 
 		for _, k := range kappaValues {
 			switch {

--- a/cmd/intensity/main.go
+++ b/cmd/intensity/main.go
@@ -1,0 +1,404 @@
+// cmd/intensity analyzes Avellaneda-Stoikov kappa (trading intensity) parameter.
+// Usage: go run ./cmd/intensity -dataset chaos -symbol BTC
+package main
+
+import (
+	"dropbear/clocky"
+	"dropbear/decimal"
+	"dropbear/ds"
+	"dropbear/indicators"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+var (
+	flagDataset   = flag.String("dataset", "chaos", "dataset name")
+	flagSymbol    = flag.String("symbol", "BTC", "coinbase product to analyze")
+	flagSamples   = flag.Int("samples", 7000, "number of samples for baseline ema")
+	flagSpread    = decimal.Flag("spread", "2", "spread threshold in basis points")
+	flagHalfLife  = clocky.DurationFlag("halflife", "5m", "intensity decay half-life")
+	flagRefKappa  = flag.Float64("refkappa", 20000, "reference kappa for scaling")
+	flagLookahead = clocky.DurationFlag("lookahead", "5m", "time to look ahead for outcome")
+)
+
+// Signal represents a trading signal with kappa context
+type Signal struct {
+	Time      clocky.Time
+	Side      ds.Side
+	Price     decimal.Decimal
+	Deviation decimal.Decimal
+	Kappa     float64
+	Scale     float64
+}
+
+// Outcome tracks what happened after a signal
+type Outcome struct {
+	Signal      Signal
+	FuturePrice decimal.Decimal
+	ProfitBPS   float64
+}
+
+func main() {
+	flag.Parse()
+
+	home := os.Getenv("HOME")
+
+	// Determine binance symbol
+	binanceSymbol := *flagSymbol + "FDUSD"
+	if *flagSymbol == "ZEC" {
+		binanceSymbol = *flagSymbol + "USDT"
+	}
+
+	// Open market data files
+	coinbasePath := home + "/marketdata/" + *flagDataset + "/coinbase/" + *flagSymbol + "-USD"
+	binancePath := home + "/marketdata/" + *flagDataset + "/binance/" + binanceSymbol
+
+	coinbaseReader := openMarketData(coinbasePath)
+	binanceReader := openMarketData(binancePath)
+	defer coinbaseReader.Close()
+	defer binanceReader.Close()
+
+	// Initialize indicators
+	spreadEMA := indicators.NewWWMA(*flagSamples)
+	intensity := indicators.NewIntensity(*flagHalfLife)
+
+	// Initialize state
+	coinbaseBook := ds.NewBook()
+	var binancePrice decimal.Decimal
+	var coinbasePrice decimal.Decimal
+	warmedUp := false
+
+	// Track kappa values and signals
+	var kappaValues []float64
+	var signals []Signal
+
+	// Price history for lookahead
+	type pricePoint struct {
+		time  clocky.Time
+		price decimal.Decimal
+	}
+	var priceHistory []pricePoint
+
+	// Read and merge ticks by time
+	var coinbaseTick, binanceTick ds.Tick
+	coinbaseErr := coinbaseReader.Read(&coinbaseTick)
+	binanceErr := binanceReader.Read(&binanceTick)
+
+	spreadThreshold := (*flagSpread).Div(decimal.Parse("10000"))
+
+	for coinbaseErr == nil || binanceErr == nil {
+		processCoinbase := false
+		processBinance := false
+
+		if coinbaseErr != nil {
+			processBinance = true
+		} else if binanceErr != nil {
+			processCoinbase = true
+		} else if coinbaseTick.Time.Before(binanceTick.Time) {
+			processCoinbase = true
+		} else {
+			processBinance = true
+		}
+
+		if processCoinbase {
+			now := coinbaseTick.Time
+
+			// Update order book
+			coinbaseBook.Lock.Lock()
+			if coinbaseTick.Snap {
+				coinbaseBook.Clear()
+			}
+			for _, bid := range coinbaseTick.Bids {
+				coinbaseBook.UpdateBid(bid.Price, bid.Size)
+			}
+			for _, ask := range coinbaseTick.Asks {
+				coinbaseBook.UpdateAsk(ask.Price, ask.Size)
+			}
+			coinbaseBook.Lock.Unlock()
+
+			// Update price and intensity from trades
+			for _, trade := range coinbaseTick.Trades {
+				if trade.Price.IsPositive() {
+					coinbasePrice = trade.Price
+					priceHistory = append(priceHistory, pricePoint{now, coinbasePrice})
+
+					// Update intensity indicator
+					mid := coinbaseBook.MidPrice()
+					if mid.IsPositive() {
+						intensity.SetMidPrice(mid)
+						intensity.AddTrade(now, trade.Price, trade.Quantity)
+					}
+				}
+			}
+
+			// Check for signals
+			if binancePrice.IsPositive() && coinbasePrice.IsPositive() {
+				spread := coinbasePrice.Sub(binancePrice).Div(binancePrice)
+				spreadEMA.Add(spread)
+
+				if spreadEMA.IsReady() && intensity.IsReady() {
+					if !warmedUp {
+						warmedUp = true
+					}
+
+					baseline := spreadEMA.Value
+					deviation := spread.Sub(baseline)
+
+					// Track kappa values
+					kappa := intensity.Kappa.Float64()
+					if kappa > 0 {
+						kappaValues = append(kappaValues, kappa)
+					}
+
+					// Compute intensity scale
+					scale := 1.0
+					if kappa > 0 {
+						scale = *flagRefKappa / kappa
+						if scale < 0.5 {
+							scale = 0.5
+						}
+						if scale > 2.0 {
+							scale = 2.0
+						}
+					}
+
+					// Adjust spread by intensity
+					adjustedThreshold := spreadThreshold.Mul(decimal.FromFloat64(scale))
+
+					// Check for signals with intensity-adjusted spreads
+					if deviation.Neg().Cmp(adjustedThreshold) > 0 {
+						signals = append(signals, Signal{
+							Time:      now,
+							Side:      ds.SideBuy,
+							Price:     coinbasePrice,
+							Deviation: deviation,
+							Kappa:     kappa,
+							Scale:     scale,
+						})
+					} else if deviation.Cmp(adjustedThreshold) > 0 {
+						signals = append(signals, Signal{
+							Time:      now,
+							Side:      ds.SideSell,
+							Price:     coinbasePrice,
+							Deviation: deviation,
+							Kappa:     kappa,
+							Scale:     scale,
+						})
+					}
+				}
+			}
+
+			coinbaseErr = coinbaseReader.Read(&coinbaseTick)
+		}
+
+		if processBinance {
+			for _, trade := range binanceTick.Trades {
+				if trade.Price.IsPositive() {
+					binancePrice = trade.Price
+				}
+			}
+			binanceErr = binanceReader.Read(&binanceTick)
+		}
+	}
+
+	// Compute outcomes for signals
+	var outcomes []Outcome
+	for _, sig := range signals {
+		futureTime := sig.Time.Add(*flagLookahead)
+		lo, hi := 0, len(priceHistory)
+		for lo < hi {
+			mid := (lo + hi) / 2
+			if priceHistory[mid].time.Before(futureTime) {
+				lo = mid + 1
+			} else {
+				hi = mid
+			}
+		}
+		if lo < len(priceHistory) {
+			futurePrice := priceHistory[lo].price
+			var profitBPS float64
+			if sig.Side == ds.SideBuy {
+				profitBPS = futurePrice.Sub(sig.Price).Div(sig.Price).BPS().Float64()
+			} else {
+				profitBPS = sig.Price.Sub(futurePrice).Div(sig.Price).BPS().Float64()
+			}
+			outcomes = append(outcomes, Outcome{sig, futurePrice, profitBPS})
+		}
+	}
+
+	// Print results
+	printResults(*flagSymbol, *flagDataset, kappaValues, outcomes)
+}
+
+type marketDataReader struct {
+	file   *os.File
+	reader *zstd.Decoder
+}
+
+func openMarketData(path string) *marketDataReader {
+	file, err := os.Open(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open %s: %v\n", path, err)
+		os.Exit(1)
+	}
+	reader, err := zstd.NewReader(file)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create zstd reader: %v\n", err)
+		os.Exit(1)
+	}
+	return &marketDataReader{file: file, reader: reader}
+}
+
+func (m *marketDataReader) Read(tick *ds.Tick) error {
+	return tick.Deserialize(m.reader)
+}
+
+func (m *marketDataReader) Close() {
+	m.reader.Close()
+	m.file.Close()
+}
+
+func printResults(symbol, dataset string, kappaValues []float64, outcomes []Outcome) {
+	fmt.Println()
+	fmt.Printf("# Intensity (Kappa) Analysis: %s/%s\n", dataset, symbol)
+	fmt.Println()
+
+	// Kappa distribution
+	if len(kappaValues) > 0 {
+		sort.Float64s(kappaValues)
+		n := len(kappaValues)
+		sum := 0.0
+		for _, k := range kappaValues {
+			sum += k
+		}
+		mean := sum / float64(n)
+
+		variance := 0.0
+		for _, k := range kappaValues {
+			diff := k - mean
+			variance += diff * diff
+		}
+		stddev := math.Sqrt(variance / float64(n))
+
+		fmt.Println("## Kappa Distribution")
+		fmt.Printf("Samples: %d\n", n)
+		fmt.Printf("Mean:    %.0f\n", mean)
+		fmt.Printf("StdDev:  %.0f\n", stddev)
+		fmt.Printf("Min:     %.0f\n", kappaValues[0])
+		fmt.Printf("Max:     %.0f\n", kappaValues[n-1])
+		fmt.Printf("P5:      %.0f\n", kappaValues[n*5/100])
+		fmt.Printf("P50:     %.0f\n", kappaValues[n/2])
+		fmt.Printf("P95:     %.0f\n", kappaValues[n*95/100])
+		fmt.Println()
+
+		// Kappa zones
+		fmt.Println("Time in Zone:")
+		veryTight := 0  // > 50000
+		tight := 0      // 20000-50000
+		normal := 0     // 10000-20000
+		loose := 0      // 5000-10000
+		veryLoose := 0  // < 5000
+
+		for _, k := range kappaValues {
+			switch {
+			case k > 50000:
+				veryTight++
+			case k > 20000:
+				tight++
+			case k > 10000:
+				normal++
+			case k > 5000:
+				loose++
+			default:
+				veryLoose++
+			}
+		}
+
+		fmt.Printf("  Very Tight (>50k):   %5.1f%%\n", float64(veryTight)/float64(n)*100)
+		fmt.Printf("  Tight (20k-50k):     %5.1f%%\n", float64(tight)/float64(n)*100)
+		fmt.Printf("  Normal (10k-20k):    %5.1f%%\n", float64(normal)/float64(n)*100)
+		fmt.Printf("  Loose (5k-10k):      %5.1f%%\n", float64(loose)/float64(n)*100)
+		fmt.Printf("  Very Loose (<5k):    %5.1f%%\n", float64(veryLoose)/float64(n)*100)
+		fmt.Println()
+	}
+
+	// Outcome by kappa zone
+	if len(outcomes) > 0 {
+		fmt.Println("## Signal Outcomes by Kappa Zone")
+
+		type stats struct {
+			count      int
+			sumProfit  float64
+			profitable int
+		}
+
+		kappaZones := map[string]*stats{
+			"very_tight": {},
+			"tight":      {},
+			"normal":     {},
+			"loose":      {},
+			"very_loose": {},
+		}
+
+		for _, o := range outcomes {
+			var zone string
+			switch {
+			case o.Signal.Kappa > 50000:
+				zone = "very_tight"
+			case o.Signal.Kappa > 20000:
+				zone = "tight"
+			case o.Signal.Kappa > 10000:
+				zone = "normal"
+			case o.Signal.Kappa > 5000:
+				zone = "loose"
+			default:
+				zone = "very_loose"
+			}
+
+			s := kappaZones[zone]
+			s.count++
+			s.sumProfit += o.ProfitBPS
+			if o.ProfitBPS > 0 {
+				s.profitable++
+			}
+		}
+
+		fmt.Printf("%-18s  %6s  %10s  %8s\n", "Kappa Zone", "Count", "Avg Profit", "Win Rate")
+		for _, name := range []string{"very_tight", "tight", "normal", "loose", "very_loose"} {
+			s := kappaZones[name]
+			if s.count > 0 {
+				avgProfit := s.sumProfit / float64(s.count)
+				winRate := float64(s.profitable) / float64(s.count) * 100
+				label := map[string]string{
+					"very_tight": "Very Tight (>50k)",
+					"tight":      "Tight (20k-50k)",
+					"normal":     "Normal (10k-20k)",
+					"loose":      "Loose (5k-10k)",
+					"very_loose": "Very Loose (<5k)",
+				}[name]
+				fmt.Printf("%-18s  %6d  %+10.2f  %7.1f%%\n", label, s.count, avgProfit, winRate)
+			}
+		}
+		fmt.Println()
+
+		// Overall stats
+		fmt.Println("## Summary")
+		total := len(outcomes)
+		var sumProfit float64
+		var profitable int
+		for _, o := range outcomes {
+			sumProfit += o.ProfitBPS
+			if o.ProfitBPS > 0 {
+				profitable++
+			}
+		}
+		fmt.Printf("Total Signals: %d\n", total)
+		fmt.Printf("Avg Profit:    %+.2fbps\n", sumProfit/float64(total))
+		fmt.Printf("Win Rate:      %.1f%%\n", float64(profitable)/float64(total)*100)
+	}
+}

--- a/cmd/spread/buygap.go
+++ b/cmd/spread/buygap.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"dropbear/clocky"
+	"dropbear/decimal"
+)
+
+// DecayMode specifies how buygap protection decays over time after sells
+type DecayMode int
+
+const (
+	DecayExponential DecayMode = iota // e^(-timeRatio*periodScale) - default
+	DecayLinear                       // max(0, 1-timeRatio) - simpler for short timescales
+	DecayNone                         // 1.0 always - no decay (constant gap)
+)
+
+// String returns the name of the decay mode
+func (d DecayMode) String() string {
+	switch d {
+	case DecayExponential:
+		return "exponential"
+	case DecayLinear:
+		return "linear"
+	case DecayNone:
+		return "none"
+	default:
+		return "unknown"
+	}
+}
+
+// ParseDecayMode parses a string into a DecayMode
+func ParseDecayMode(s string) DecayMode {
+	switch s {
+	case "exponential":
+		return DecayExponential
+	case "linear":
+		return DecayLinear
+	case "none":
+		return DecayNone
+	default:
+		return DecayExponential // default to current behavior
+	}
+}
+
+// CalculateDecayFactor computes the decay factor for buygap protection
+// Returns a value in [0, 1] where:
+//   - 1.0 = full gap protection (just sold, don't buy near same price)
+//   - 0.0 = no gap protection (enough time has passed)
+//
+// Parameters:
+//   - mode: decay algorithm to use
+//   - timeSinceSell: duration since last sell
+//   - decayPeriod: base decay period (e.g., 30s)
+//   - inventoryRatio: current inventory / target (used for exponential mode)
+func CalculateDecayFactor(mode DecayMode, timeSinceSell clocky.Duration, decayPeriod clocky.Duration, inventoryRatio decimal.Decimal) decimal.Decimal {
+	if timeSinceSell <= 0 || decayPeriod <= 0 {
+		return decimal.One
+	}
+
+	switch mode {
+	case DecayExponential:
+		// Current behavior: e^(-timeRatio*periodScale)
+		// periodScale = e^(-inventoryRatio*2)
+		// This makes decay slower when inventory is high
+		timeRatio := decimal.FromInt(int(timeSinceSell)).Div(decimal.FromInt(int(decayPeriod)))
+		periodScale := inventoryRatio.MulInt(2).Neg().Exp()   // e^(-invRatio*2)
+		decayFactor := timeRatio.Mul(periodScale).Neg().Exp() // e^(-timeRatio*periodScale)
+		return decayFactor.Max(decimal.Zero).Min(decimal.One)
+
+	case DecayLinear:
+		// Linear decay: 1 - (timeSinceSell / decayPeriod)
+		// Simpler, more predictable for short timescales
+		timeRatio := decimal.FromInt(int(timeSinceSell)).Div(decimal.FromInt(int(decayPeriod)))
+		decayFactor := decimal.One.Sub(timeRatio)
+		return decayFactor.Max(decimal.Zero).Min(decimal.One)
+
+	case DecayNone:
+		// No decay - always full gap protection
+		return decimal.One
+
+	default:
+		return decimal.One
+	}
+}
+
+// BuyGapMetrics tracks gap protection statistics
+type BuyGapMetrics struct {
+	SignalsTotal    int // Total buy signals evaluated
+	SignalsBlocked  int // Blocked by gap protection
+	SignalsExecuted int // Passed gap check
+}
+
+// BlockRate returns the percentage of signals blocked
+func (m *BuyGapMetrics) BlockRate() float64 {
+	if m.SignalsTotal == 0 {
+		return 0
+	}
+	return float64(m.SignalsBlocked) / float64(m.SignalsTotal) * 100
+}
+
+// Reset clears the metrics
+func (m *BuyGapMetrics) Reset() {
+	m.SignalsTotal = 0
+	m.SignalsBlocked = 0
+	m.SignalsExecuted = 0
+}

--- a/cmd/spread/buygap_test.go
+++ b/cmd/spread/buygap_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"dropbear/clocky"
+	"dropbear/decimal"
+	"testing"
+)
+
+func TestDecayModeString(t *testing.T) {
+	tests := []struct {
+		mode DecayMode
+		want string
+	}{
+		{DecayExponential, "exponential"},
+		{DecayLinear, "linear"},
+		{DecayNone, "none"},
+	}
+
+	for _, tt := range tests {
+		got := tt.mode.String()
+		if got != tt.want {
+			t.Errorf("DecayMode(%d).String() = %s, want %s", tt.mode, got, tt.want)
+		}
+	}
+}
+
+func TestParseDecayMode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  DecayMode
+	}{
+		{"exponential", DecayExponential},
+		{"linear", DecayLinear},
+		{"none", DecayNone},
+		{"invalid", DecayExponential}, // defaults to exponential
+		{"", DecayExponential},
+	}
+
+	for _, tt := range tests {
+		got := ParseDecayMode(tt.input)
+		if got != tt.want {
+			t.Errorf("ParseDecayMode(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestCalculateDecayFactor_Linear(t *testing.T) {
+	tests := []struct {
+		name           string
+		timeSinceSell  clocky.Duration
+		decayPeriod    clocky.Duration
+		inventoryRatio decimal.Decimal
+		want           decimal.Decimal
+	}{
+		{
+			name:           "zero time",
+			timeSinceSell:  0,
+			decayPeriod:    30 * clocky.Second,
+			inventoryRatio: decimal.Zero,
+			want:           decimal.One, // full protection
+		},
+		{
+			name:           "half period",
+			timeSinceSell:  15 * clocky.Second,
+			decayPeriod:    30 * clocky.Second,
+			inventoryRatio: decimal.Zero,
+			want:           decimal.Parse("0.5"),
+		},
+		{
+			name:           "full period",
+			timeSinceSell:  30 * clocky.Second,
+			decayPeriod:    30 * clocky.Second,
+			inventoryRatio: decimal.Zero,
+			want:           decimal.Zero, // no protection
+		},
+		{
+			name:           "past period",
+			timeSinceSell:  60 * clocky.Second,
+			decayPeriod:    30 * clocky.Second,
+			inventoryRatio: decimal.Zero,
+			want:           decimal.Zero, // clamped to zero
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CalculateDecayFactor(DecayLinear, tt.timeSinceSell, tt.decayPeriod, tt.inventoryRatio)
+			if got.Cmp(tt.want) != 0 {
+				t.Errorf("CalculateDecayFactor(Linear, %v, %v, %v) = %v, want %v",
+					tt.timeSinceSell, tt.decayPeriod, tt.inventoryRatio, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCalculateDecayFactor_None(t *testing.T) {
+	tests := []struct {
+		name          string
+		timeSinceSell clocky.Duration
+		decayPeriod   clocky.Duration
+	}{
+		{"zero time", 0, 30 * clocky.Second},
+		{"some time", 15 * clocky.Second, 30 * clocky.Second},
+		{"past period", 60 * clocky.Second, 30 * clocky.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CalculateDecayFactor(DecayNone, tt.timeSinceSell, tt.decayPeriod, decimal.Zero)
+			if got.Cmp(decimal.One) != 0 {
+				t.Errorf("CalculateDecayFactor(None, %v, %v, 0) = %v, want 1.0",
+					tt.timeSinceSell, tt.decayPeriod, got)
+			}
+		})
+	}
+}
+
+func TestCalculateDecayFactor_Exponential(t *testing.T) {
+	// Test that exponential mode returns values in [0,1]
+	tests := []struct {
+		name           string
+		timeSinceSell  clocky.Duration
+		decayPeriod    clocky.Duration
+		inventoryRatio decimal.Decimal
+	}{
+		{"zero time", 0, 30 * clocky.Second, decimal.Zero},
+		{"half period low inv", 15 * clocky.Second, 30 * clocky.Second, decimal.Parse("0.5")},
+		{"full period", 30 * clocky.Second, 30 * clocky.Second, decimal.One},
+		{"past period", 60 * clocky.Second, 30 * clocky.Second, decimal.Parse("1.5")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CalculateDecayFactor(DecayExponential, tt.timeSinceSell, tt.decayPeriod, tt.inventoryRatio)
+			// Should be in [0, 1]
+			if got.Cmp(decimal.Zero) < 0 || got.Cmp(decimal.One) > 0 {
+				t.Errorf("CalculateDecayFactor(Exponential, %v, %v, %v) = %v, want in [0,1]",
+					tt.timeSinceSell, tt.decayPeriod, tt.inventoryRatio, got)
+			}
+		})
+	}
+}
+
+func TestBuyGapMetrics_BlockRate(t *testing.T) {
+	tests := []struct {
+		name     string
+		metrics  BuyGapMetrics
+		wantRate float64
+	}{
+		{
+			name:     "no signals",
+			metrics:  BuyGapMetrics{SignalsTotal: 0, SignalsBlocked: 0, SignalsExecuted: 0},
+			wantRate: 0,
+		},
+		{
+			name:     "all blocked",
+			metrics:  BuyGapMetrics{SignalsTotal: 100, SignalsBlocked: 100, SignalsExecuted: 0},
+			wantRate: 100,
+		},
+		{
+			name:     "none blocked",
+			metrics:  BuyGapMetrics{SignalsTotal: 100, SignalsBlocked: 0, SignalsExecuted: 100},
+			wantRate: 0,
+		},
+		{
+			name:     "half blocked",
+			metrics:  BuyGapMetrics{SignalsTotal: 100, SignalsBlocked: 50, SignalsExecuted: 50},
+			wantRate: 50,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.metrics.BlockRate()
+			if got != tt.wantRate {
+				t.Errorf("BlockRate() = %v, want %v", got, tt.wantRate)
+			}
+		})
+	}
+}
+
+func TestBuyGapMetrics_Reset(t *testing.T) {
+	m := BuyGapMetrics{
+		SignalsTotal:    100,
+		SignalsBlocked:  50,
+		SignalsExecuted: 50,
+	}
+
+	m.Reset()
+
+	if m.SignalsTotal != 0 || m.SignalsBlocked != 0 || m.SignalsExecuted != 0 {
+		t.Errorf("Reset() failed: got %+v, want all zeros", m)
+	}
+}

--- a/cmd/spread/main.go
+++ b/cmd/spread/main.go
@@ -33,6 +33,7 @@ var (
 	flagPanic     = decimal.FlagBPS("panic", "15", "panic threshold to sell at a loss")
 	flagBuyGap    = decimal.FlagBPS("buygap", "5", "only buy if price is this many basis points below last buy")
 	flagBuyDecay  = clocky.DurationFlag("decay", "30s", "base decay period for buygap after sells")
+	flagDecayMode = flag.String("decay-mode", "exponential", "decay mode: exponential, linear, none")
 	flagSkew      = decimal.Flag("skew", "1", "spread adjustment per 100% inventory imbalance")
 	flagWindow    = clocky.DurationFlag("window", "42m", "time window for min/max range protection (0 disables)")
 	flagComfort   = decimal.FlagPercent("comfort", "20", "percent of min/max window we're comfortable buying or selling")
@@ -68,6 +69,8 @@ var (
 	gPriceMax      *indicators.Max
 	gFirstEvent    clocky.Time
 	gWarmedUp      bool
+	gBuyGapMetrics BuyGapMetrics
+	gDecayMode     DecayMode
 )
 
 func main() {
@@ -75,8 +78,11 @@ func main() {
 	loggy.Init()
 	teddy.Init()
 
-	log.Printf("spread=%sbps, panic=%sbps, samples=%d, cooldown=%s, size=$%s, window=%s comfort=%s danger=%s intensity=%s",
-		(*flagSpread).BPS(), (*flagPanic).BPS(), *flagSamples, *flagCooldown, *flagSize, *flagWindow, *flagComfort, *flagDanger, *flagIntensity)
+	gDecayMode = ParseDecayMode(*flagDecayMode)
+
+	log.Printf("spread=%sbps, panic=%sbps, samples=%d, cooldown=%s, size=$%s, window=%s comfort=%s danger=%s intensity=%s buygap=%sbps decay=%s decay-mode=%s",
+		(*flagSpread).BPS(), (*flagPanic).BPS(), *flagSamples, *flagCooldown, *flagSize, *flagWindow, *flagComfort, *flagDanger, *flagIntensity,
+		(*flagBuyGap).BPS(), *flagBuyDecay, gDecayMode)
 
 	gSpreadEMA = indicators.NewWWMA(*flagSamples)
 	if *flagWindow != 0 {
@@ -397,24 +403,20 @@ func executeTrade(now clocky.Time, side ds.Side, spread decimal.Decimal) {
 			}
 
 			// calculate decay factor based on time since last sell
-			// decay period = basePeriod * e^(inventoryRatio * 2)
 			decayFactor := decimal.One
 			if (*flagTarget).IsPositive() && gLastSellTime > 0 {
 				invRatio := invested.Div(*flagTarget)
-				timeSinceSell := now - gLastSellTime
-				if timeSinceSell > 0 {
-					timeRatio := decimal.FromInt(int(timeSinceSell)).Div(decimal.FromInt(int(*flagBuyDecay)))
-					periodScale := invRatio.MulInt(2).Neg().Exp()                // e^(-invRatio*2)
-					decayFactor = timeRatio.Mul(periodScale).Neg().Exp()         // e^(-timeRatio*periodScale)
-					decayFactor = decayFactor.Max(decimal.Zero).Min(decimal.One) // clamp [0,1]
-				}
+				timeSinceSell := clocky.Duration(now - gLastSellTime)
+				decayFactor = CalculateDecayFactor(gDecayMode, timeSinceSell, *flagBuyDecay, invRatio)
 			}
 
 			// effective buygap = base * inventoryScale * decayFactor
 			effectiveBuygap := (*flagBuyGap).Mul(inventoryScale).Mul(decayFactor)
 			if effectiveBuygap.BPS().Cmp(decimal.Tenth) > 0 {
+				gBuyGapMetrics.SignalsTotal++
 				maxBuyPrice := topCost.Mul(decimal.One.Sub(effectiveBuygap))
 				if buyPrice.Cmp(maxBuyPrice) > 0 {
+					gBuyGapMetrics.SignalsBlocked++
 					if *flagVerbose {
 						gap := topCost.Sub(buyPrice).Div(topCost)
 						log.Printf("[logic] skip buy: price $%s not %sbps below last buy $%s (gap=%sbps scale=%s decay=%s%% inv=$%s)",
@@ -429,6 +431,7 @@ func executeTrade(now clocky.Time, side ds.Side, spread decimal.Decimal) {
 					}
 					return
 				}
+				gBuyGapMetrics.SignalsExecuted++
 			}
 		}
 	}

--- a/msg/market.go
+++ b/msg/market.go
@@ -1,0 +1,62 @@
+// Package msg defines message types for the actor system.
+// Messages are passed between actors via mailboxes.
+package msg
+
+import (
+	"dropbear/clocky"
+	"dropbear/decimal"
+	"dropbear/ds"
+)
+
+// BinanceTick is emitted by the Binance ingest actor when trade data arrives.
+// Contains the latest trade price and time from Binance.
+type BinanceTick struct {
+	Time   clocky.Time
+	Price  decimal.Decimal
+	Trades []ds.Trade // raw trades for intensity calculation
+}
+
+// CoinbaseTick is emitted by the Coinbase ingest actor when order book changes.
+// Contains bid/ask prices and the mid price.
+type CoinbaseTick struct {
+	Time clocky.Time
+	Bid  decimal.Decimal
+	Ask  decimal.Decimal
+	Mid  decimal.Decimal
+}
+
+// PriceRange is emitted by the indicator actor with min/max range.
+type PriceRange struct {
+	Time clocky.Time
+	Min  decimal.Decimal
+	Max  decimal.Decimal
+}
+
+// IntensityUpdate is emitted when trading intensity (kappa) changes.
+type IntensityUpdate struct {
+	Time  clocky.Time
+	Kappa decimal.Decimal // Avellaneda-Stoikov intensity parameter
+}
+
+// SpreadUpdate is emitted by the indicator actor with spread baseline.
+type SpreadUpdate struct {
+	Time      clocky.Time
+	Spread    decimal.Decimal // current spread
+	Baseline  decimal.Decimal // EMA baseline
+	Deviation decimal.Decimal // spread - baseline
+	Ready     bool            // true when EMA is warmed up
+}
+
+// MarketState aggregates all market data needed for signal generation.
+// This is the input to the spread calculation actor.
+type MarketState struct {
+	Time          clocky.Time
+	BinancePrice  decimal.Decimal
+	CoinbasePrice decimal.Decimal
+	CoinbaseMin   decimal.Decimal
+	CoinbaseMax   decimal.Decimal
+	SpreadEMA     decimal.Decimal
+	Kappa         decimal.Decimal
+	LastBinance   clocky.Time
+	LastCoinbase  clocky.Time
+}

--- a/msg/signal.go
+++ b/msg/signal.go
@@ -1,0 +1,79 @@
+package msg
+
+import (
+	"dropbear/clocky"
+	"dropbear/decimal"
+	"dropbear/ds"
+)
+
+// Disposition indicates where price is in the recent range.
+type Disposition int
+
+const (
+	DispositionNormal Disposition = iota
+	DispositionCheap
+	DispositionTooCheap
+	DispositionExpensive
+	DispositionTooExpensive
+)
+
+// SpreadSignal is emitted when a trading opportunity is detected.
+type SpreadSignal struct {
+	Time        clocky.Time
+	Side        ds.Side
+	Deviation   decimal.Decimal // spread deviation from baseline
+	Disposition Disposition
+	BuySpread   decimal.Decimal // adjusted spread threshold for buying
+	SellSpread  decimal.Decimal // adjusted spread threshold for selling
+}
+
+// TradeIntent is emitted by the spread actor when it wants to trade.
+// This goes to the risk actor for validation.
+type TradeIntent struct {
+	Time      clocky.Time
+	Side      ds.Side
+	Quantity  decimal.Decimal
+	Price     decimal.Decimal // expected fill price
+	Deviation decimal.Decimal // spread deviation that triggered this
+}
+
+// TradeResult is emitted after a trade is executed.
+type TradeResult struct {
+	Time      clocky.Time
+	Side      ds.Side
+	Quantity  decimal.Decimal
+	Price     decimal.Decimal // actual fill price
+	Slippage  decimal.Decimal // price slippage
+	Success   bool
+	Error     string
+	OrderTime clocky.Duration // time to place order
+	FillTime  clocky.Duration // time to get fill confirmation
+}
+
+// InventoryState is emitted by the accounting actor.
+type InventoryState struct {
+	Time       clocky.Time
+	Quantity   decimal.Decimal
+	CostBasis  decimal.Decimal
+	BuyVolume  decimal.Decimal
+	SellVolume decimal.Decimal
+	WinCount   int
+	LossCount  int
+}
+
+// HealthScore is computed from inventory balance and win rate.
+type HealthScore struct {
+	Time    clocky.Time
+	Balance decimal.Decimal // min(buy,sell)/max(buy,sell)
+	WinRate decimal.Decimal // wins/(wins+losses)
+	Score   decimal.Decimal // balance * winRate
+}
+
+// GreedFactor is computed from inventory imbalance.
+type GreedFactor struct {
+	Time       clocky.Time
+	Imbalance  decimal.Decimal // (inventory - target) / target
+	Greed      decimal.Decimal // exp(imbalance * skew)
+	BuySpread  decimal.Decimal // spread * greed
+	SellSpread decimal.Decimal // spread / greed
+}


### PR DESCRIPTION
## Summary

Analyzed buy gap protection effectiveness and added configurable decay modes for better tuning. Analysis showed gap protection blocks 90% of signals with decay having minimal effect due to rapid signal clustering.

## Changes

### New Features
- **New analyzer tool**: `cmd/buygap` measures gap protection effectiveness
- **Decay mode flag**: `-decay-mode={exponential,linear,none}` for configurable decay
- **Metrics tracking**: Runtime visibility into gap protection behavior
- **Comprehensive tests**: Full test coverage for decay functions

### Analysis Findings
- **BTC**: 89.8% of signals blocked by gap protection
- **DOGE**: 98.1% blocked (potentially too aggressive)
- **Median time-since-sell**: 0 seconds (signals cluster rapidly)
- **Recommendation**: Linear decay may be more appropriate for sub-second timescales

## Files Changed
- `cmd/buygap/main.go` - New analyzer tool (438 lines)
- `cmd/spread/buygap.go` - Refactored decay logic with tests
- `cmd/spread/buygap_test.go` - Comprehensive test suite
- `cmd/spread/main.go` - Integrated new flag and metrics
- `BUYGAP_ANALYSIS.md` - Detailed findings and recommendations
- `ARCHITECTURE.md` - Design decisions and rationale

## Testing
- ✅ All unit tests pass: `go test ./...`
- ✅ Analyzer verified on chaos/BTC dataset
- ✅ Backward compatible: defaults to exponential (current behavior)
- ✅ Code formatted with `go fmt`

## Usage

```bash
# Use new decay modes
go run ./cmd/spread -decay-mode linear
go run ./cmd/spread -decay-mode none

# Analyze gap effectiveness
go run ./cmd/buygap -dataset chaos -symbol BTC
```

## Backward Compatibility
Fully backward compatible - defaults to `exponential` decay mode (current behavior). No breaking changes.