### PR TITLE
fixes 0dte option chain selection in cboe/cadence.go

### DIFF
--- a/cboe/cadence.go
+++ b/cboe/cadence.go
@@ -107,10 +107,10 @@ func HasOptionChain(sym symbol.Symbol, year int, month clocky.Month, day int) bo
 
 func GetNextOptionChain(sym symbol.Symbol, year int, month clocky.Month, day int) (int, clocky.Month, int) {
 	for {
-		year, month, day = addDays(year, month, day, 1)
 		if HasOptionChain(sym, year, month, day) {
 			return year, month, day
 		}
+		year, month, day = addDays(year, month, day, 1)
 	}
 }
 

--- a/cboe/cadence_test.go
+++ b/cboe/cadence_test.go
@@ -1,0 +1,26 @@
+package cboe
+
+import (
+	"dropbear/clocky"
+	"dropbear/symbol"
+	"testing"
+	"time"
+)
+
+func TestGetNextOptionChain(t *testing.T) {
+	tests := []struct {
+		sym       symbol.Symbol
+		now       clocky.Time
+		wantChain clocky.Time
+	}{
+		// On 2026-04-22, the option chain expring 2026-04-24 was chosen, but should have chosen 0-DTE chain on the same day
+		{symbol.GOOGL, clocky.Date(2026, clocky.April, 22, 13, 30, 0, 0, time.UTC), clocky.Date(2026, clocky.April, 22, 13, 30, 0, 0, time.UTC)},
+		{symbol.SPXW, clocky.Date(2026, clocky.April, 22, 13, 30, 0, 0, time.UTC), clocky.Date(2026, clocky.April, 22, 13, 30, 0, 0, time.UTC)},
+	}
+	for _, tt := range tests {
+		gotChainYear, gotChainMonth, gotChainDay := GetNextOptionChain(tt.sym, tt.now.Year(), tt.now.Month(), tt.now.Day())
+		if gotChainYear != tt.wantChain.Year() || gotChainMonth != tt.wantChain.Month() || gotChainDay != tt.wantChain.Day() {
+			t.Errorf("%s: GetNextOptionChain() got date = %d-%d-%d, want %d-%d-%d", tt.sym, gotChainYear, gotChainMonth, gotChainDay, tt.wantChain.Year(), tt.wantChain.Month(), tt.wantChain.Day())
+		}
+	}
+}


### PR DESCRIPTION
We select the next option chain here https://github.com/jart/dropbear/blob/1e4a2861357a8dfd37c6650e5e818690fae08531/cmd/strangler/bento.go#L96

but always increment the day before checking the passed date as a valid option chain candidate.