### PR TITLE
Reconnect databento streams instead of crashing; dedupe reconnect logic

### DIFF
--- a/broker/alpaca/orderupdates.go
+++ b/broker/alpaca/orderupdates.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 )
 
 type OrderUpdate struct {
@@ -40,22 +39,7 @@ type orderUpdatesDaemon struct {
 }
 
 func (d *orderUpdatesDaemon) run() {
-	try := 0
-	for {
-		ts1 := time.Now()
-		err := d.impl()
-		ts2 := time.Now()
-		if err != nil {
-			logf("error reading message: %v\n", err)
-		}
-		elapsed := ts2.Sub(ts1)
-		if elapsed > 30*time.Second {
-			try = 0 // connection was healthy so reset backoff
-		}
-		wait := time.Duration(15<<min(try, 11)) * time.Millisecond
-		time.Sleep(wait) // waits for 30 seconds max
-		try++
-	}
+	netty.Reconnect("alpaca order updates", d.impl, logf)
 }
 
 func (d *orderUpdatesDaemon) impl() error {

--- a/broker/schwab/orderupdates.go
+++ b/broker/schwab/orderupdates.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 )
 
 // OrderUpdates returns a channel that receives order update events via the Schwab streamer WebSocket.
@@ -30,21 +29,7 @@ type orderUpdatesDaemon struct {
 }
 
 func (d *orderUpdatesDaemon) run() {
-	try := 0
-	for {
-		ts1 := time.Now()
-		err := d.impl()
-		ts2 := time.Now()
-		if err != nil {
-			logf("error reading message: %v\n", err)
-		}
-		if ts2.Sub(ts1) > 30*time.Second {
-			try = 0 // connection was healthy so reset backoff
-		}
-		wait := time.Duration(15<<min(try, 11)) * time.Millisecond
-		time.Sleep(wait)
-		try++
-	}
+	netty.Reconnect("schwab order updates", d.impl, logf)
 }
 
 func (d *orderUpdatesDaemon) impl() error {

--- a/cmd/strangler/bento.go
+++ b/cmd/strangler/bento.go
@@ -4,6 +4,7 @@ import (
 	"dropbear/broker/databento"
 	"dropbear/cboe"
 	"dropbear/clocky"
+	"dropbear/netty"
 	"dropbear/options"
 	"dropbear/osi"
 	"dropbear/symbol"
@@ -12,38 +13,53 @@ import (
 	"log"
 )
 
+// streamEquities subscribes to equity definitions and quotes on a single live
+// gateway connection.
 func (t *Trader) streamEquities(key databento.ApiKey, defs chan<- *options.Equity, ticks chan<- *databento.MBP1) {
+	netty.Reconnect("equity stream", func() error {
+		return t.streamEquitiesOnce(key, defs, ticks)
+	}, log.Printf)
+}
+
+func (t *Trader) streamEquitiesOnce(key databento.ApiKey, defs chan<- *options.Equity, ticks chan<- *databento.MBP1) error {
 	client, err := databento.Dial("EQUS.MINI", key)
 	if err != nil {
-		log.Fatalf("dial: %v", err)
+		return fmt.Errorf("dial: %w", err)
 	}
 	defer client.Close()
 	dbSymbol := fmt.Sprintf("%s", t.Config.Symbol)
-	client.MustSubscribe(databento.Subscription{
+	if err := client.Subscribe(databento.Subscription{
 		Schema:  databento.SchemaDefinition,
 		SType:   databento.STypeRawSymbol,
 		Symbols: []string{dbSymbol},
-	})
-	client.MustSubscribe(databento.Subscription{
+	}); err != nil {
+		return fmt.Errorf("subscribe definitions: %w", err)
+	}
+	if err := client.Subscribe(databento.Subscription{
 		Schema:  databento.SchemaMBP1,
 		SType:   databento.STypeRawSymbol,
 		Symbols: []string{dbSymbol},
-	})
-	meta := client.MustStart()
+	}); err != nil {
+		return fmt.Errorf("subscribe quotes: %w", err)
+	}
+	meta, err := client.Start()
+	if err != nil {
+		return fmt.Errorf("start: %w", err)
+	}
 	log.Printf("streaming %s (dbn v%d)", dbSymbol, meta.Version)
 	for {
 		rec, err := client.Read()
 		if err != nil {
 			if err == io.EOF {
-				return
+				return fmt.Errorf("stream closed")
 			}
-			log.Fatalf("decode: %v", err)
+			return fmt.Errorf("decode: %w", err)
 		}
 		switch m := rec.(type) {
 		case *databento.ErrorMsg:
-			log.Fatalf("option gateway error: %s", m.Err)
+			return fmt.Errorf("equity gateway error: %s", m.Err)
 		case *databento.SystemMsg:
-			log.Printf("option system message: %s", m.Msg)
+			log.Printf("equity system message: %s", m.Msg)
 		case *databento.SymbolMappingMsg:
 			id := m.Header.InstrumentID
 			str := m.GetSTypeOutSymbol()
@@ -74,23 +90,36 @@ func (t *Trader) streamEquities(key databento.ApiKey, defs chan<- *options.Equit
 // maps parent symbols to instrument IDs with OSI names. This avoids the
 // historical API which can time out.
 func (t *Trader) streamOptions(key databento.ApiKey, defs chan<- *options.Option, ticks chan<- *databento.CMBP1) {
+	netty.Reconnect("option stream", func() error {
+		return t.streamOptionsOnce(key, defs, ticks)
+	}, log.Printf)
+}
+
+func (t *Trader) streamOptionsOnce(key databento.ApiKey, defs chan<- *options.Option, ticks chan<- *databento.CMBP1) error {
 	client, err := databento.Dial("OPRA.PILLAR", key)
 	if err != nil {
-		log.Fatalf("dial: %v", err)
+		return fmt.Errorf("dial: %w", err)
 	}
 	defer client.Close()
 	dbSymbol := fmt.Sprintf("%s.OPT", t.Config.Symbol)
-	client.MustSubscribe(databento.Subscription{
+	if err := client.Subscribe(databento.Subscription{
 		Schema:  databento.SchemaDefinition,
 		SType:   databento.STypeParent,
 		Symbols: []string{dbSymbol},
-	})
-	client.MustSubscribe(databento.Subscription{
+	}); err != nil {
+		return fmt.Errorf("subscribe definitions: %w", err)
+	}
+	if err := client.Subscribe(databento.Subscription{
 		Schema:  databento.SchemaCMBP1,
 		SType:   databento.STypeParent,
 		Symbols: []string{dbSymbol},
-	})
-	meta := client.MustStart()
+	}); err != nil {
+		return fmt.Errorf("subscribe quotes: %w", err)
+	}
+	meta, err := client.Start()
+	if err != nil {
+		return fmt.Errorf("start: %w", err)
+	}
 	log.Printf("streaming %s (dbn v%d)", dbSymbol, meta.Version)
 	wantYear, wantMonth, wantDay := clocky.Now().Date()
 	wantYear, wantMonth, wantDay = cboe.GetNextOptionChain(t.Config.Symbol, wantYear, wantMonth, wantDay)
@@ -99,13 +128,13 @@ func (t *Trader) streamOptions(key databento.ApiKey, defs chan<- *options.Option
 		rec, err := client.Read()
 		if err != nil {
 			if err == io.EOF {
-				return
+				return fmt.Errorf("stream closed")
 			}
-			log.Fatalf("decode: %v", err)
+			return fmt.Errorf("decode: %w", err)
 		}
 		switch m := rec.(type) {
 		case *databento.ErrorMsg:
-			log.Fatalf("option gateway error: %s", m.Err)
+			return fmt.Errorf("option gateway error: %s", m.Err)
 		case *databento.SystemMsg:
 			log.Printf("option system message: %s", m.Msg)
 		case *databento.SymbolMappingMsg:

--- a/cmd/varu/live.go
+++ b/cmd/varu/live.go
@@ -4,6 +4,7 @@ import (
 	"dropbear/broker/databento"
 	"dropbear/broker/schwab"
 	"dropbear/clocky"
+	"dropbear/netty"
 	"dropbear/options"
 	"dropbear/osi"
 	"fmt"
@@ -117,36 +118,49 @@ func (t *Trader) Live() {
 // maps parent symbols to instrument IDs with OSI names. This avoids the
 // historical API which can time out.
 func (t *Trader) streamOptions(key databento.ApiKey, defs chan<- *options.Option, ticks chan<- *databento.CMBP1) {
+	netty.Reconnect("option stream", func() error {
+		return t.streamOptionsOnce(key, defs, ticks)
+	}, log.Printf)
+}
+
+func (t *Trader) streamOptionsOnce(key databento.ApiKey, defs chan<- *options.Option, ticks chan<- *databento.CMBP1) error {
 	client, err := databento.Dial("OPRA.PILLAR", key)
 	if err != nil {
-		log.Fatalf("dial: %v", err)
+		return fmt.Errorf("dial: %w", err)
 	}
 	defer client.Close()
 	dbSymbol := fmt.Sprintf("%s.OPT", t.Symbol)
-	client.MustSubscribe(databento.Subscription{
+	if err := client.Subscribe(databento.Subscription{
 		Schema:  databento.SchemaDefinition,
 		SType:   databento.STypeParent,
 		Symbols: []string{dbSymbol},
-	})
-	client.MustSubscribe(databento.Subscription{
+	}); err != nil {
+		return fmt.Errorf("subscribe definitions: %w", err)
+	}
+	if err := client.Subscribe(databento.Subscription{
 		Schema:  databento.SchemaCMBP1,
 		SType:   databento.STypeParent,
 		Symbols: []string{dbSymbol},
-	})
-	meta := client.MustStart()
+	}); err != nil {
+		return fmt.Errorf("subscribe quotes: %w", err)
+	}
+	meta, err := client.Start()
+	if err != nil {
+		return fmt.Errorf("start: %w", err)
+	}
 	log.Printf("streaming %s (dbn v%d)", dbSymbol, meta.Version)
 	wantYear, wantMonth, wantDay := clocky.Now().Date()
 	for {
 		rec, err := client.Read()
 		if err != nil {
 			if err == io.EOF {
-				return
+				return fmt.Errorf("stream closed")
 			}
-			log.Fatalf("decode: %v", err)
+			return fmt.Errorf("decode: %w", err)
 		}
 		switch m := rec.(type) {
 		case *databento.ErrorMsg:
-			log.Fatalf("option gateway error: %s", m.Err)
+			return fmt.Errorf("option gateway error: %s", m.Err)
 		case *databento.SystemMsg:
 			log.Printf("option system message: %s", m.Msg)
 		case *databento.SymbolMappingMsg:

--- a/netty/reconnect.go
+++ b/netty/reconnect.go
@@ -1,0 +1,25 @@
+package netty
+
+import "dropbear/clocky"
+
+// Reconnect calls fn in a loop forever, applying exponential backoff between
+// failed attempts (capped at roughly 30s). If an attempt stays up longer
+// than 30s before failing, the backoff resets to its minimum so a feed that
+// drops after being healthy for a while doesn't inherit a long wait from an
+// earlier failure streak. logf is called with the error after every failed
+// attempt; pass nil to disable logging.
+func Reconnect(name string, fn func() error, logf func(format string, v ...any)) {
+	try := 0
+	for {
+		start := clocky.Now()
+		err := fn()
+		if err != nil && logf != nil {
+			logf("%s error, reconnecting: %v", name, err)
+		}
+		if clocky.Since(start) > 30*clocky.Second {
+			try = 0 // connection was healthy so reset backoff
+		}
+		clocky.Sleep(clocky.Duration(15<<min(try, 11)) * clocky.Millisecond)
+		try++
+	}
+}


### PR DESCRIPTION
Databento streaming errors (dial, subscribe, decode, gateway) used to call `log.Fatalf`, killing the whole trader on any blip. These now reconnect with exponential backoff, matching the policy schwab/alpaca order-update streams already used.

- Extracted that backoff loop into `netty.Reconnect`, shared by all 5 places that had it duplicated: the 3 databento streams (new) plus the 2 pre-existing order-update daemons in `broker/schwab` and `broker/alpaca` (no behavior change, just deduplication). A 6th copy in `alpaca/stockupdates.go` has a different lifecycle and was left alone.
- Switched to `clocky` instead of stdlib `time`.
- Fixed a mislabeled equity-stream error ("option gateway error" → "equity").

**Flag for review:** for the databento streams specifically, permanent failures (e.g. revoked API key) now retry forever and log instead of crashing — no more hard process-death signal for a supervisor to catch.

`go vet`/`fmt`/`test ./...` all pass.